### PR TITLE
adds 2014 team abstracts to Team Seeker

### DIFF
--- a/app/teams.json
+++ b/app/teams.json
@@ -4744,5 +4744,1349 @@
 "Year":2013,
 "Description":" Converting E. coli into a foundry for bioplastics",
 "Abstract":"Poly(lactic acid) (PLA) is a biodegradable, biocompatible, bioresorbable, thermoplastic bioplastic that offers many advantages over other biomaterials in both commercial and medical applications. The current chemical method of synthesizing PLA is expensive, and the required processing and purifying steps use many environmentally unfriendly chemicals. Recently, E. coli has been engineered to produce PLA, but low yields and short chain lengths prevent the approach’s commercial use. Here, we evaluate the potential of using multiplex automated genome engineering to raise both yields and chain lengths of biosynthesized PLA by directing the E. coli metabolism to funnel resources toward PLA production without sacrificing the organism’s viability. Efficient biosynthesis of PLA, which may be thus achieved, would be a significant step in reducing the impact of plastic waste, and would benefit those receiving bone implants. It would also open up a new possibility in rapid manufacturing of personalized bone implants using three-dimensional printers"
+},
+{
+"Team":"Aachen",
+"Year":2014,
+"Description":"Cellock Holmes - a novel SynBio platform to detect pathogens",
+"Abstract":"Detection and identification of microbial contaminations on hard surfaces are vital to reduce the incidence of nosocomial infections and to alleviate the pressure on health care systems. Existing techniques pose limitations, as they do not combine effective, economical and rapid detection. The Cellock Holmes project aims to tackle these challenges all at once. By combining native microbial sensing systems, such as quorum sensing, with open source biology, hardware and software, a novel two-dimensional biosensor is developed. Cellock Holmes’ simple, modular and open design enables the end user to test solid surfaces for microbial contamination without any expensive equipment or highly trained personnel. The working concept is demonstrated using one of the most prevalent human pathogens, Pseudomonas aeruginosa. The versatile biosensing system, however, can be easily customized to detect other pathogens as well. Cellock Holmes - a novel SynBio platform to detect pathogens."
+},
+{
+"Team":"Aalto-Helsinki",
+"Year":2014,
+"Description":"Aalto-Helsinki Bioworks - A Synthetic Biology Startup with a Three-Channel Gene Switch",
+"Abstract":"We have engineered a three-channel switch that is controlled with the intensity of blue light. By utilizing the mechanisms of the lambda repressor, we are able to switch between the expressions of three different genes with a short delay. This kind of mechanism provides a nearly real-time control over genes, which could provide advantages in variety of industrial bioprocesses. Inspired by the principles of open source software, we introduce an Open Sequence business model implemented around our switch. We want to encourage future companies to create Open Sequence based solutions and to empower customers to participate in the product development. Open Sequence model’s transparency as well as lower degree of protection raises trust and continuity and benefits larger community. We want to share our experiences and insights in biotech entrepreneurship and address the difficulties that students and newcomers may face in the early stages of building a synthetic biology startup."
+},
+{
+"Team":"Aberdeen Scotland",
+"Year":2014,
+"Description":"E.coli display of peptide mimotopes, integrated with quorum-sensing AND logic, for diagnosis of tropical diseases",
+"Abstract":"Trypanosoma.b. gambiense, the causative agent of Trypanosomiasis (African Sleeping Sickness) infects 30,000 people worldwide, with 60 million at disease risk. Unrecognised, this disease is fatal, but accurate diagnosis, relying on detection of patient serum antibodies against two different trypanosomal antigens, allows successful treatment. We engineered autotransporters Ag43 and ice-nucleation protein to successfully express surface epitopes in E.coli that mimic two different trypanosomal antigens. Two E.coli strains were generated, each expressing a distinct surface epitope and either a quorum sensing (QS) sender or receiver module respectively. Immune pull-down of each strain, and their subsequent co-culture, produced a quorum signal, indicating successful detection of two distinct antibody populations in a serum sample. We constructed a cheap, Raspberry Pi computer-controlled fluorimeter suitable for developing countries, showing it could detect QS fluorescence output. This novel application of antigen display, and quorum sensing to implement AND logic sensing, facilitates cheap, simple diagnosis of tropical diseases."
+},
+{
+"Team":"AHUT China",
+"Year":2014,
+"Description":"BIO-COMPASS",
+"Abstract":"The aim of our project is to build a brand new bio-navigational system that can be used by the ordinary people. The map information will be coded in DNA strand and do corresponding biochemical operations. The bio-navigational database will establish the relationship between biochemical operation instructions and traditional navigation instructions. In order to reduce workload in advance, BIO-COMPASS can also screen reaction conditions according to the road conditions. Furthermore, we try to update the system to adapt to the more complex path plans. For this, we design some special enzyme sites which differ from standard bio-bricks’ as the function interfaces. For example, “Logic Gate” genetic device can be inserted in our system to help us solve the path plan which include a transfer station between the start and the destination. BIO-COMPASS will find the best solution by using a variety of detection methods such as electrophoresis and reporter gene."
+},
+{
+"Team":"Aix-Marseille",
+"Year":2014,
+"Description":"S.E.colization : Green light, GO!",
+"Abstract":"The S.E.colization project focuses on synchronizing a culture of E.coli cells, so that they divide synchronously and change color from green to red and back as they go through the cell cycle. More specifically the culture stops dividing full of red cells and at regular intervals the cells turn green and divide before returning to the red quiescent state. To control the cell cycle, this project relies on a re-engineered chemotaxis system which instead of controlling the flagellar rotation direction drives changes in gene expression in response of the cell community through the use of a series of on/off switches and a modified serine production pathway which allows between cell communication. Introduced together, these different components will create an oscillator that regularly drives the switch modules between their two states which coupled to color changes will make the cells GO to the other state only when the light is green!!"
+},
+{
+"Team":"AMU-Poznan",
+"Year":2014,
+"Description":"sh-miR designer v2.0 - a user-friendly tool for sh-miR prediction",
+"Abstract":"RNA interference (RNAi) is a one of the post-transcriptional gene expression regulation process. The process occurs physiologically, but it can also be employed in biological research. RNAi reagents such as siRNAs, shRNAs and sh-miRs (also called artificial miRNAs or sh-miRNAs) are widely used in molecular biology. They can be used in basic research or in therapeutic approaches for genetic diseases. sh-miR designer is user-friendly and fast software for sh-miR design and in silico validation. In sh-miR designer v2.0 only the mRNA number (from NCBI database) can be provided to predict molecules targeting desired transcript. Moreover, we expanded functionality of the software with off-target validation and immune motifs presence verification and also extended the miRNA-shuttles database. With sh-miR designer we automated the tedious and time-consuming process of sh-miR design."
+},
+{
+"Team":"Arizona State",
+"Year":2014,
+"Description":"Microbial Communities Making Biodiesel",
+"Abstract":"The Arizona State iGEM team aims to produce biodiesel in a new and efficient way using Escherichia coli. Using a wax esterase, fatty acids and ethanol, both naturally produced by E. coli, can be combined to form biodiesel. However, E. coli uses the same intermediate products to produce both fatty acids and ethanol, which reduces the efficiency of this process. This problem can be avoided by engineering two different strains of E. coli to work in tandem. One strain will be engineered to produce free fatty acids (FFA) through expression of enzymes including as TesA and acc. The other strain will be engineered to produce ethanol through expression of enzymes including pdc and adhB. These two products will be combined in one of the two cells using a waxy esterase, producing the final biodiesel product. Cooperative production will hopefully produce more ethanol than current single strain methods using E. coli."
+},
+{
+"Team":"ArtCenter MDP",
+"Year":2014,
+"Description":"Car Pools",
+"Abstract":"Synthetic biology assumes a future for modified organisms beyond the lab. Biofuel research is currently focusing on genetically engineered algae to produce gasoline, with the goal of one day being commercially distributed. This objective has created a network of open-ponds for algae production, dispersed across the southwest of the United States. As synthetic biology moves out of the lab into the wild, what are the ecological effects associated with the release of a modified organism? Car Pools is a series of simulations that examine potential ecological effects associated with the public release of modified algae for biofuel production. The project draws on current open-pond algae production methods to imagine a future fuel-pool infrastructure for Los Angeles, a metropolis built for cars and where there are more than 43,000 swimming pools. The project plays out different scales of interaction, the home, the neighborhood, and the city, to imagine future ecosystems."
+},
+{
+"Team":"ATOMS-Turkiye",
+"Year":2014,
+"Description":"Change of Heart",
+"Abstract":"Tissue hypoxia, or ischemia, is the condition that describes the poor conveyance of oxygen and other vital products to body tissues and organs which consequently results tissue death. Up to now, the number one cause of death worldwide is caused by ischemia and related conditions such as heart attack or stroke. It is needed to regard the big picture of the condition in order to solve the problem. In our project, our will is to build two different devices, which work synergistically, to fix these two distinct situations. We decided to use 'hypoxia inducible systems' and 'reactive oxygen species (ROS) sensitive gene fragments'. These two receptors will hopefully regulate the release of clot dissolving factors and antioxidant peptides synthesized by our engineered vessel cells. We hope to bring encouraging results in vitro to pave the way of this promising system into the lifesaving remedy method."
+},
+{
+"Team":"Auckland New Zealand",
+"Year":2014,
+"Description":"The microbial bandage",
+"Abstract":"Despite living in an era of rapid biological advancements, the millennium-old complication of infection prevention and relevant medical intervention has yet to receive the perfect solution. Current prevention methods consist of the application of antibiotics. Though proven to be effective in the past, the rise of antibiotic resistance of microbes, especially those in hospital environments, has showed this is not a feasible long term solution. Research into human intestinal microbiota has led to insight in the importance of interaction between humans and their endogenous microorganisms. Despite not being as extensively documented as gut microbiota, skin microbiota has been implied to provide protection against bacterial infection. The iGEM team of Auckland, New Zealand, aims incorporate relevant biobricks of past projects along with novel biobricks to genetically engineer a bacterial based barrier/bandage with the intention of preventing of bacterial infection."
+},
+{
+"Team":"Austin Texas",
+"Year":2014,
+"Description":"The Genetic Code Expansion Pack",
+"Abstract":"Expansion of the genetic code has the potential to add novel functionality and chemistry to biology. Typically, expansion occurs via reassignment of the amber stop codon. When reassigned, this codon results in incorporation of a non-canonical amino acid (ncAA) not normally found in proteins. Such ncAAs can grant new functionality, including photocrosslinking, photocaging, novel bonding or binding sites, and fluorescence. One part of our project creates an “Expansion Pack Reporter Kit”. This kit uses a fused fluorescent reporter, containing an N-terminal RFP domain, a C-terminal GFP domain, and an amber codon-containing linker sequence that connects the two domains. While the RFP domain is translated and fluoresces under all conditions, the GFP domain is only translated when the ncAA is incorporated within the linker. Failure to incorporate the ncAA leads to translation termination, and thus no GFP fluorescence. This allows us to accurately assess the rate and fidelity of ncAA incorporation."
+},
+{
+"Team":"Berlin",
+"Year":2014,
+"Description":"A remote control for E. coli",
+"Abstract":"As the first iGEM team from Berlin, we decided to construct a simple BioBrick that enables synthetic biologists to remotely control the movement of E. coli. A seemingly simple and non-invasive mechanism for this remote control is the use of magnetic fields. By altering the iron homeostasis of E. coli, we want to increase the total iron level of the cytosol. By sequestering iron in a ferritin protein, iron crystals are formed and the cell is detoxified. We will work with other metal binding proteins such as metallothioneins and phytochelatin synthases in order to create ferromagnetic crystals. Furthermore, we will search for the optimal conditions which yield the most efficient formation of magnetic nanoparticles in E. coli. Once we have discovered the best way to magnetize E. coli bacteria, we will build and characterize suitable BioBricks that can be used to remote control the cellular movement of E. coli."
+},
+{
+"Team":"BGU Israel",
+"Year":2014,
+"Description":"The Inner Doctor - Treating the Metabolic Syndrome from within!",
+"Abstract":"Western modern lifestyle brought us a lot of wonderful innovations, but also many problems. Today, about 25% of the adult world population suffers from the Metabolic Syndrome. This syndrome is a cluster of dangerous medical conditions, including: obesity, insulin resistance, high blood triglycerides and more. These medical conditions are interconnected and are a result of complex metabolic pathways, meaning most traditional drugs used to treat them have undesired side effects. We intend to utilize synthetic biology in order to develop novel strategies for the treatment of the Metabolic Syndrome. By addressing the causes of the syndrome rather than its symptoms, and by doing so in several different fronts, we hope to present a safe and better way to improve global health!"
+},
+{
+"Team":"Bielefeld-CeBiTe",
+"Year":2014,
+"Description":"The Transformers - From carbon dioxide to biofuel",
+"Abstract":"The supply with electricity is facing three major problems: the storage of electricity, the increasing amount of atmospheric carbon dioxide and the development of alternative energy sources. Therefore we want to implement a proof of concept for the production of the biofuel isobutanol from carbon dioxide. A bacterial microcompartment originated from cyanobacteria, called carboxysome, is used to realize the fixation of carbon dioxide in Escherichia coli. Within this microcompartment the carbon dioxide fixation is enabled under aerobic conditions. The needed energy for this process is provided by electricity. The electrons are transferred with a mediator into the cells and its uptake is empowered by different modifications of E. coli, like over-expression of the fumarate reductase. This concept is realized in a self-constructed bioreactor. Finally the production of isobutanol is established by hetereologous expression of various enzymes from different species."
+},
+{
+"Team":"BIOSINT Mexico",
+"Year":2014,
+"Description":"Green Demon",
+"Abstract":"In Mexico and around the world there is an urgent need to implement measures to reduce heavy metal soil pollution. Different treatments have been used including in situ and ex situ, which have proven extremely expensive and impractical for large scale areas. For this project we have designed a modular system, plastic and ready to incorporate to A. thaliana; in order to extract the metals, in particular mercury, from the soil and convert it into a less reactive species. The final challenge is to develop a measurable, specific, effective, safe and low-cost treatment for large areas of contaminated soil."
+},
+{
+"Team":"BIT",
+"Year":2014,
+"Description":"radiation-dosimeter, new siren for radiation harm",
+"Abstract":"In recent decades, human have stepped out to explore the universe. Astronauts have been sent to outer space. In the meantime, how to prevent radiation harm has become a serious problem that demands promting solution. Our project focuses on establishing a more portable, accurate and economical biosynthetic system to detect the dosage, and to provide measurement precisely to guard human from being hurt by invisible radiation. We assembly gene circuits in E.coli, which function as radiation detector and reporter individually. Meanwhile, we design bi-switch circuits for the detector, a quorum sensing circuits for reporter and a linkage between the two. Once the detector senses radiation by the damage, the linkage auto-inducer molecules will drive the reporter to produce light and digital signals. We firmly believe that this biological-activity-based detector system is more sensitive, and has more significant influence in measuring the level of harm by sensing the dosage of radiation."
+},
+{
+"Team":"BIT-China",
+"Year":2014,
+"Description":"E.co-Lock",
+"Abstract":"BIT-China designed a genetic lock E.co-Lock in bacteria to keep important strains safe from ecological threatening or commercial loss even when they are accidentally leaked out or intentionally stolen. This bio-lock, likened to a digital combination lock, allows bacteria to grow only if three different inducers as password is put in order. To realize the code function three layered AND logic gates combined with sRNA system are built up. The corresponding sRNA selectively inhibits gene expression in AND gates to control the order of the password. MIN system is re-designed to inhibit cell division, which will be turned on to maintain the strain to a low density. In a word, locked bacteria are allowed to grow only when the input is correct; thus strains would remain low density and are effectively locked up. Therefore, commercially valuable or potentially hazardous strains will be under more strict control with different customized E.co-Locks."
+},
+{
+"Team":"BNU-China",
+"Year":2014,
+"Description":"E.coil Promethus",
+"Abstract":"Nitrogen fixing ability of rhizobium is significant for the growth of grass family. The stronger of its ability, the less chemical fertilizer will be used. Molybdenum is a key integral part of nitrogen fixing enzyme in rhizobium and Mo is also important for the growth of plants themselves. However, Mo is heavy mental. The abuse of it will cause environment pollution. Hence, spot application of Mo is of great importance. A plasmid was transfer into E.coli Promethus to make it express fusion protein, one side of which anchors on the out membrane and the other side of which,ModA,catches molybdate. With the help of organic acid tendency system, our Promethus will head for the roots. A suicide system depending on time is also design for the reason of bio-safety. E.coli Promethus will deliver Mo directly to the root of plants. This will also open a new chapter of biological fertilizer."
+},
+{
+"Team":"Bordeaux",
+"Year":2014,
+"Description":"Elasticoli",
+"Abstract":"Elastin, Resilin and Spider Silk (Spidroin) are elastomeric protein found in nature. These biomaterials provide properties like high stress resistance and high elasticity. To produce these proteins, synthetics genes were engineered for E.Coli and it inspired by consensus sequences found in natural peptides, for elastin like polypeptides (ELP) the consensus sequence is VPGXG where X can be different amino acids, on the same way GPGXG, GPGGY and GPGGV were identified for spider silk like polypeptides (SLP) and finally for resilin like polypeptides (RLP) there is PSXXYGAP. Proteins are produce, after they are purified and freeze-dried to measure the dry-mass. Further soluble proteins are wet spin to obtain strings and test physicals properties. The final goal is to assembly ELP, RLP and SLP to create new polymers properties. The biobrick assembly method is used and optimized to combine fragments without stop codon to obtain new innovative proteins."
+},
+{
+"Team":"BostonU",
+"Year":2014,
+"Description":"The Joy of Cloning: Chimera, a Recipe for Integrating Computational Tools with Experimental Protocols",
+"Abstract":"If BU can clone it, so can you! With a pinch of wet lab work and a dash of computational tools, we have developed a new recipe called Chimera that will help fellow synthetic biology cloners in the creation of their genetic devices! Chimera utilizes bio-design automation software tools with experimental protocols and builds upon a thoroughly characterized library of MoClo parts. This recipe, or workflow, integrates software tools to reduce human error and to structure the way device designs are chosen, assembled, and tested. To demonstrate that this workflow can be used by any level of cloner (beginner, intermediate, and advanced), we will highlight how we used Chimera to create [1] individual genetic parts (namely tandem promoters, fusion proteins, and different backbones), [2] transcriptional units assembled from individual parts (with both new and previously made MoClo parts), and [3] a complex genetic device (our goal is a priority encoder)."
+},
+{
+"Team":"Brasil-SP",
+"Year":2014,
+"Description":"Kidney sensing - toward a bacterial biosensor engineered for early stages chronic kidney disease",
+"Abstract":"Chronic Kidney Disease (CKD), which is characterized by alterations in kidney functions and structure, affects millions of people worldwide and a large portion of them is unaware of it. Absence of symptoms in early stages leads to a late diagnosis when patients need dialysis or even transplants. Currently, CKD is diagnosed by measuring creatinine levels in blood, which in turn are detectable only at late stages of renal dysfunction as well as are sensitive to factors such as diet, gender, ethnicity, age, muscle mass. We report the development of a biosensor that can diagnosis CKD in its early stages, identifying a biomarker named Cystatin C. Using a cell surface biosensor as detector and quorum-sensing system as transducer and response mechanism, we developed a genetic circuit that establishes a tthreshold, differentiating concentration ranges of Cystatin C. We envisioned it as a fast, simple and reliable tool for CKD screening and diagnosis."
+},
+{
+"Team":"Braunschweig",
+"Year":2014,
+"Description":"E. cowli -fighting climate change where it begins-",
+"Abstract":"Milk cows and cattle are important factors in global warming: In their rumen, billions of microorganisms release greenhouse gases such as carbon dioxide and methane as they help digest the animal’s food. Even though this is a natural process industrial-scale farming intensifies the situation. Therefore, finding ways to decrease production of such gases damaging to climate is essential. Considering the 25 times greater contribution to global warming compared to CO2, methane emission is a substantial point of action for future climate protection. In order to achieve this, we are going to engineer a bacterium in a way that it is able to render methane harmless just as it originates in the cow’s rumen. The bacterium shall be equipped with the 6 subunits of the monooxygenase (MMO) out of Methylococcus capsulatus turning methane into a natural intermediate of the cellular metabolism so that no methane is released into the atmosphere."
+},
+{
+"Team":"British Columbia",
+"Year":2014,
+"Description":"Darwin’s Metals",
+"Abstract":"The local mining industry is an important economic sector for British Columbia, Canada. With increasing mandates calling for “sustainable mining initiatives”, one of the aims is to reduce the environmental impact of mining by increasing mining efficiency through innovative ways. Our project seeks to improve physical separation processes by targeting chalcopyrite (CuFeS2) and sphalerite (ZnS) minerals in natural ores using unique metal-binding peptides displayed on the S-layer of Caulobacter crescentus. We furthered our work by developing a novel directed evolution apparatus that will provide us new tools in improving ore separation, thereby granting our technology versatility and adaptability for biomining. This biological approach provides an alternative in mineral processing that involves fewer harmful chemicals, greater selectivity and better recovery of metals in complex or lower grade ores."
+},
+{
+"Team":"BUCT-China",
+"Year":2014,
+"Description":"A water quality detection method based on constitutively bioluminescent E. coli and microfluidics",
+"Abstract":"Human beings have been suffering from contaminated water a lot since first industrial revolution. Both of water protection and water examination are of great importance. Here, we aim at rapidly testing a multiply water sample, finding out whether it’s toxic or not and making a specific toxin detection, these toxin materials may be heavy metals and nitrate that contained in the contaminated water. To achieve this, we design a bio-system-recombinant luminous Escherichia coli to which diverse bio-sensors are transformed. Then we ascertain the quality of water by analysis the light intensity which correlated to the expression of lux gene reflecting comprehensive toxicity and multi-FP genes indicating specific toxicities. All these test data are analyzed in a algorithm we designed which give feedback in the form of report including referable information. Furthermore, adding microfluidics to this system will make the trace and fast test possible."
+},
+{
+"Team":"BUGSS Baltimore",
+"Year":2014,
+"Description":"Polymerase to the people!",
+"Abstract":"The DIY bio community has developed a number of open source, inexpensive designs for laboratory equipment necessary for synthetic biology, but the prices of commercial DNA polymerases remain a significant financial hurdle for labs operating on shoestring budgets. Founding members of the Baltimore Underground Science Space (BUGSS) began to address this problem in the 2010 iGEM competition, developing a Biobrick for Taq polymerase synthesis. BUGSS has built on this earlier work, developing a new Biobrick for Pfu DNA polymerase, which offers a replication error rate approximately 6 fold lower than that of Taq. The development of this Biobrick began with the amplification and cloning of the pol gene for Pfu DNA polymerase from contaminant DNA in a commercial stock enzyme. Modifications were made for compatibility with Biobrick Assembly Standard 10. BUGSS is now developing a kit for easy purification of Pfu polymerase to reduce the cost of this essential tool."
+},
+{
+"Team":"BYU Provo",
+"Year":2014,
+"Description":"Reclaiming water reclamation: Engineering microbes for enhanced sewage treatment",
+"Abstract":"Wastewater facilities face challenges in effectively processing waste including residual antibiotics, excess nitrates, biofilm buildup and low survival rates of microbes essential to biodegredation. Using the native sludge bacteria Nitrosospira multiformis and Nitrosomonas eutropha as chassis we inserted genes to produce erythromycin esterase B and β-lactamase to breakdown azythromycin and penicillin. We also inserted nirS, norB, norC, and nosZ from Pseudomonas aeruginosa PAO1 to convert nitrates into nitrogen gas, as well as genes to produce dispersin, amylase, and AHL-lactonase to inhibit biofilm formation. To increase bacteriophage resistance, prophage in the Nitrosospira and Nitrosomonas genomes were identified and used to build a guide RNA region for a Type II CRISPR system. By deleting the serA and serB genes we engineered serine auxotrophs to prevent release of our modified microbes. These improvements will help reduce antibiotic resistance, increase water reclamation, prevent algal blooms, and allow more biomass to be harvested."
+},
+{
+"Team":"Calgary",
+"Year":2014,
+"Description":"B.s. Detector – A Multiplexed Diagnostic Device",
+"Abstract":"Infectious diseases symptomatically similar to malaria are often misdiagnosed in resource-poor, developing countries. Misdiagnosis of such diseases prevents administration of the appropriate treatments in a timely manner, resulting in economic burdens and human suffering. The 2014 Calgary iGEM team has engaged with international infectious diseases experts and end-users to address this issue. We are developing a novel, nucleic acid-based, rapid point-of-care device capable of diagnosing multiple infectious diseases in parallel. Bacillus subtilis is being engineered to generate a chromophoric reporter in response to genetic markers from disease-causing pathogens. B. subtilis spores in a portable, handheld device will be used to detect pathogen DNA capitalizing on an innate mechanism of homologous recombination to express a reporter through a transcriptionally-regulated genetic circuit. Our platform technology can be adapted to detect a myriad of pathogens by modifying the genetic markers to which the system is targeted."
+},
+{
+"Team":"Caltech",
+"Year":2014,
+"Description":"Implementation of Non-Endogenous Bacterial Quorum Sensing Systems in E. coli",
+"Abstract":"While there exist many well-characterized genetic circuits in synthetic biology utilizing intracellular genetic regulation, the implementation of methods governing intercellular regulation—that between two different cells—has lagged behind in comparison. To investigate the viability of independent, non-interfering cell-to-cell signaling, we attempted to implement non-endogenous bacterial quorum-sensing systems from various Gram positive bacteria in E. coli, in hopes that successful transfer of these systems into E. coli will promote enhanced prototyping of intercellular signaling and regulation in synthetic biology’s favorite model organism. To this end, three separate quorum sensing systems—agrBDCA, lamBDCA, and fsrABC—were investigated. We constructed various cell strains expressing separately the signaling and receiving components of the quorum sensing systems and measured their efficacy in creating and receiving the signaling molecule. Treatment of hormonal regulation disorders (e.g. diabetes, Cushing’s disease, etc.) is one of many possible applications of successful creation of circuits implementing intercellular regulation."
+},
+{
+"Team":"Cambridge-JIC",
+"Year":2014,
+"Description":"mösbi - the plant biosensor for everyone",
+"Abstract":"The past few decades have seen detection technology change dramatically. The shift from analogue to digital came first. Now, a new change is happening: biosensors are allowing mankind to detect compounds and the environment using genetically-enhanced life forms. However the creation of such biosensors requires deep knowledge and dedicated facilities. What if it were possible to create customised biosensors in the comfort of one’s home? mösbi is a modular, open-source biosensing platform developed using a novel, user-friendly plant chassis: Marchantia polymorpha. The mösbi biosensors consist of 3 modules: input, output and processing. The user is free to mix-and-match the modules to create custom biosensors simply by crossing the chosen modules’ pre-transformed plant lines and collecting the progeny. mösbi’s open-source nature allows users to create and modify modules ensuring its continuous evolution. In farming, homes, education, and maybe even space - mösbi will change the way we view biosensors."
+},
+{
+"Team":"Carnegie Mellon",
+"Year":2014,
+"Description":"STREAM: Sensor That Reports Endocrine Activating Molecules",
+"Abstract":"Detection of hormones in the environment has raised concerns recently because of their potential to affect both humans and wildlife. Estrogens from natural, synthetic, plant, and fungal sources show endocrine disrupting properties and even at low concentrations have harmful effects due to receptor activation. A sensor was constructed using the ligand binding domain of the human estrogen receptor. Estrogenic activity occurs in water sources including waste, drinking, and freshwater. In freshwater, estrogens are harmful to the ecosystems, feminizing fish and disrupting populations of organisms. Additionally, estrogenic substances can be present in what we drink. However, since the presence of hormones in water is a relatively new area of study there have been no previous restrictions or regulations regarding removal of estrogenic compounds. The sensor and fish ecosystems were modeled and middle school outreach kits for Creature Feature and DNA extraction and hybridization were created to demonstrate concepts of synthetic biology."
+},
+{
+"Team":"CAU China",
+"Year":2014,
+"Description":"Frozen by E.coli",
+"Abstract":"We move the frozen power from Disney to E.coli. We construct E.coli to express RFP to draw a dynamic pattern of snowflake. Once we kindle a spot, the pattern starts and grows up gradually. According to our design, two kinds of E.coli with partly different genetic pathway align alternatively. The two kinds of E.coli interact through two independent quorum sensing systems, LuxI/LuxR/AHL in vibrio fischeri and RpaI/RpaR/pC-HSL in Rhodopseudomonas palustris, while neither of them influencing themselves. A plate for E.coli culture is divided into rectangular grids and every “cell” in the grid is occupied with a colon of E.coli. On-state shows as red fluorescence while off-state shows as nothing illuminating. To kindle the system, we only need to add correspondent signal molecular to the central 4 colons of E.coli in a plate. Finally, there will be a snowflake with red fluorescence starts to grow up from a point automatically."
+},
+{
+"Team":"CityU HK",
+"Year":2014,
+"Description":"Fit Coli – Enhancement of human health by converting excess fat to ALA and DHA",
+"Abstract":"Obesity has now reached epidemic proportions worldwide, which has serious consequences because obesity is associated with various chronic human diseases such as diabetes, hypertension and cardiovascular diseases. With the aim to protect oneself against obesity and debilitating diseases caused by a high-fat diet, we are using a synthetic biology approach to design an Escherichia coli strain (called Fit Coli) that has an enhanced ability to uptake and convert excess fatty acids from fatty foods into a-linolenic acid (ALA). The strategy is to engineer the fadL and fadD genes along with three desaturase genes to facilitate the uptake of long-chain fatty acids and their biotransformation to ALA by the “Fit Coli” strain. It is predicted that the ALA converted from excess fatty acids by Fit Coli is converted to docosahexaenoic acid (DHA), an omega-3-fatty acid, in the human gut, which is well known to have many positive health benefits."
+},
+{
+"Team":"Colombia",
+"Year":2014,
+"Description":"ChOL Bio-Sensor",
+"Abstract":"Our project aims to use synthetic biology to develop a V. cholerae sensor using a new technique. Instead of trying to detect the cholerae toxin, specific sequences of nucleic acid, or antigens, we propose detecting V. cholerae Autoinducer 1 (CAI-1), the bacteria’s species-specific quorum sensing molecule. If we rewire V. cholerae’s own quorum sensing mechanism –used in nature to gauge population levels and regulate pathogenicity– in a harmless E. coli chassis, we can build a cheap and easy-to-use biosensor that gives a color output when it senses the pathogen. This prototype can serve as a proof-of-concept for future quorum sensing-based pathogen biosensors."
+},
+{
+"Team":"Concordia",
+"Year":2014,
+"Description":"Clean Green Lipid Machines: Synthetic biology tools for microalgae",
+"Abstract":"Unicellular microalgae are a varied group of organisms with excellent potential in applied and exploratory synthetic biology. With their photosynthetic and mixotrophic abilities, these organisms have the promise of becoming platforms for carbon-neutral production of both high-value and inexpensive metabolites. Starting with the goal of making microalgae an easier to engineer chassis, we set out to create a specialised toolkit of standardised biological parts. We strove to characterise a complete range of microalgal parts, including promoters, terminators, fluorescent proteins, localisation tags, antibiotic markers, and CRISPR/Cas. The diverse group of species we used included four distinct Chlorella spp. and Chlamydomonas reinhardtii. These species display a broad range of growth conditions and metabolic profiles. With the creation of standardised tools for the stable engineering of microalgae, the community will be able to continue asking deeper questions about basic biology and, drastically increase the promise of microalgae as industrial hosts."
+},
+{
+"Team":"Cooper Union",
+"Year":2014,
+"Description":"Micro-Toolbox: Open Source Solutions for DNA Synthesis Biosafety and SynBio Education",
+"Abstract":"Tools that compress the “design-build-test” cycle in synthetic biology are especially needed to reliably advance scientific proof-of-concepts to the industrial scale. As DNA synthesis continues to be a major bottleneck for R&D, our open source solution utilizes a novel enzymatic approach towards controllable *de novo* DNA synthesis; performed rapidly, inexpensively and less toxic than current methods. With speedy synthesis comes greater responsibility in industry towards biosafety; we propose the ultimate kill switch mechanism, a yeast-based chassis that features a programmable lifespan based on telomeres. Simplified DNA assembly will lead to a greater emphasis on pathway design and characterization in bioengineering programs. For schools, our “Biohacker Kit” utilizes a modular input/output binary plasmid platform that allows students to rapidly generate and test multiple biosensor configurations, with no “cutting and pasting” required. Additionally, inexpensive access to quality laboratory gear will be made possible by our “Open Hardware” collection of devices."
+},
+{
+"Team":"Cornell",
+"Year":2014,
+"Description":"Lead it go: Heavy metal sequestration from regional contaminated waters using genetically engineered E.coli",
+"Abstract":"Heavy metal pollution in water is one of the most significant public health risks around the world. Pollutants including lead, mercury, and nickel can enter water supplies through improper disposal of waste, industrial manufacturing, and mining. Previous researchers have developed biological methods of heavy metal sequestration utilizing heavy metal transport proteins and metallothioneins, a class of low-molecular weight proteins with high binding affinities for heavy metals. In these genetically engineered systems, the transport proteins will preferentially transport a specific heavy metal into the cell and the metallothionein will aggressively bind--driving flux into the cell and sequestering the toxic metal. Our research aims to modularize previous sequestration systems for nickel and mercury utilizing a yeast metallothionein/glutathione-s-transferase fusion protein as well the transport proteins NixA (nickel transporter) and merT/merP (mercury transporter). We also plan to extend this sequestration system using a putative lead transport protein."
+},
+{
+"Team":"CSU Fort Collins",
+"Year":2014,
+"Description":"Using Frying Oil to Produce High Value Products in an engineered strain of Escherichia coli",
+"Abstract":"Approximately 3 billion gallons per year of frying oil are used in the United States. The purpose of this project is to create a value added product from used frying oil as the feedstock. Escherichia coli is being engineered to breakdown lipids to acetyl-CoA and produce a high value terpenoid based product through the mevalonate pathway. A biosensor will be incorporated to detect the presence of lipids via the interaction of acyl-CoA with FadR which results in the de-repression of Green Fluorescent Protein. For added security, a kill switch is being developed to destroy the cell if released into the environment. The protein KillerRed is repressed in the presence of tryptophan. In the absence of tryptophan and in the presence of light, KillerRed will kill the cell through the production of reactive oxygen species. The progress on the various parts of the project will be presented."
+},
+{
+"Team":"CU-Boulder",
+"Year":2014,
+"Description":"CRISPR-Cas9 mediated phage therapy provides a sequence-specific alternative to antibiotics",
+"Abstract":"Over the past few decades, the number of antibiotic resistant bacteria has increased steadily; meanwhile, antibiotic production has fallen exponentially. In order to address the growing threat of antibiotic resistance in bacteria, new antibacterial agents are required. We have engineered a novel phage therapy utilizing the endogenous CRISPR-Cas9 system from Streptococcus pyogenes packaged into non-replicating phage. CRISPR-Cas9 systems target 20-32 nucleotide DNA sequences within the bacterial genome. Successful CRISPR targeting to the genome leads to a Cas9-mediated DNA double strand break and subsequent cell death. By cloning targeted CRISPR sequences into the endogenous CRISPR-Cas9 system and introducing this system into Escherichia coli by transformation or through phage infection, we have demonstrated sequence specific killing of bacteria in a heterogeneous bacterial population. The broad ranging applications of such an adaptable and cost effective antibiotic therapy range from healthcare to agriculture and represent the future of antibacterial research."
+},
+{
+"Team":"DTU-Denmark",
+"Year":2014,
+"Description":"Advancing Synthetic Biology: Measuring promoter activities using the Spinach RNA aptamer",
+"Abstract":"Since promoters are an integral part of every biological system, thorough characterization of promoters is a prerequisite for quick and robust construction of devices in synthetic biology. We have developed a method for measuring promoter activity in absolute units, that can be used to better characterize promoters. The method uses a fluorescent RNA reporter called Spinach and allows calculation of promoter activity in Polymerases per Second (PoPS). Furthermore the RNA reporter enables direct assessment of transcriptional activity without the factor of translational efficiency. In addition to this we have created a brainstorming exercise with the dual purpose of sparking an interest in synthetic biology among high school students, and providing the community with ideas for synthetic biology projects. Finally we have performed an analysis of the ethical issues associated with synthetic biology. All the efforts in our project have thus been directed towards advancing the field of synthetic biology."
+},
+{
+"Team":"Duke",
+"Year":2014,
+"Description":"Developing an ultra-sensitive response in CRISPR circuitry",
+"Abstract":"Biological tools that are based on the CRISPR/Cas9 system could potentially enable synthetic biologists to create gene circuits of far greater complexity than what was previously possible. However, the function or robustness of many circuits relies on ultrasensitive, switch-like responses from the transcription factors involved. Currently, CRISPR-based tools have distinctively analog, non-Boolean responses, making them unsuitable for use in functions that require a steep response curve. Tools that introduce Boolean-like ultra-sensitivity into the CRISPR system would increase its versatility for applications in complex gene circuits. We are implementing two possible approaches to demonstrating ultra-sensitivity in CRISPR: cooperative repression and molecular titration."
+},
+{
+"Team":"Dundee",
+"Year":2014,
+"Description":"The Lung Ranger",
+"Abstract":"Cystic fibrosis is among the most common inherited disorders in Caucasian populations. It is caused by mutations in the CFTR gene and results in a thick mucus covering epithelia. This is particularly problematic in the respiratory tract, which becomes chronically infected with pathogenic bacteria. The Dundee 2014 iGEM project is focused on designing and testing a device that will rapidly and non-invasively identify these bacteria. We have developed biosensors to recognise signalling molecules that are released by the bacteria and can be detected in a patient’s sputum. The biosensors will be housed in an electronic device that can be used as a point-of-care test for a patient’s respiratory microbiome. ‘The Lung Ranger’ is a portable tool designed to be faster and easier to use than current diagnostic techniques, allowing clinicians to make decisions about a patient’s treatment in a matter of hours rather than days."
+},
+{
+"Team":"Edinburgh",
+"Year":2014,
+"Description":"RewirED: Introducing a new intercellular signalling mechanism based on metabolic pathways - Metabolic Wiring",
+"Abstract":"The Edinburgh team is introducing a newly invented inter-cellular communication method to iGEM, called Metabolic Wiring. This signalling method uses intermediates from metabolic pathways as signalling molecules, and is superior to the conventionally used quorum sensing due to improved orthogonality, wider range of signalling molecules available, and extensibility. Our project aims to implement the system in Escherichia coli and adapt it to BioBrick format. We will develop three metabolic wires using aromatic degradation, sugar degradation, and cis-genic wires. To demonstrate its potential, the three wires will then be implemented in a population control system and used to regulate the growth of a single bacterial strain in a mixed population, depending on the population sizes of the remaining strains. Stability of composition of the bacterial populations can thus be increased and more complex biochemical reactions enabled. We will also attempt an alternative use of the wires in an intracellular genetic circuit."
+},
+{
+"Team":"EPF Lausanne",
+"Year":2014,
+"Description":"BioPad",
+"Abstract":"The BioPad project aims to study how biological signals can be detected and processed in a fast and precise way. To illustrate this vision of biology, our team created the world’s first biological TouchPad. On top of serving as a living TouchPad, the BioPad will serve as a fast antibiotic screening device, an apparatus allowing the study of gene activation, and a perfect way to introduce synthetic biology and bio-hardware to the general public via a graspable project. Our BioPad is made of three components: touch responsive organisms, a custom microfluidic chip, and a mini-computer serving as a signal detector. Once touched, the BioPad responds quickly by emitting light or fluorescence. The biological engineering behind our project combines protein complementation techniques to dimerization in E. Coli and S. cerevisiae stress pathways. Split reporter proteins from fluorescent proteins, and luciferases were fused to the dimerizing proteins, allowing signal emission upon stress."
+},
+{
+"Team":"ETH Zurich",
+"Year":2014,
+"Description":"Mosaicoli – From simplicity to complexity with biologic gates",
+"Abstract":"Emergence of complex patterns in nature is a fascinating, widely spread phenomenon, which is not fully understood yet. Mosaicoli aims at investigating emergence of complex patterns from a simple rule by engineering a cellular automaton into E. coli. This automaton comprises a grid of colonies on a 3D-printed millifuidic chip. Each colony is either in an ON or OFF state and updates its state by integrating signals from its neighbors according to a genetically pre-programmed logic rule. Complex patterns, like Sierpinski triangles, are visualized by fluorescence after several steps of row-wise propagation. The implementation of quorum sensing based sequential logic computation is challenged by leakiness and crosstalk present in biological systems. Mosaicoli overcomes these issues by exploiting multichannel orthogonal communication, riboregulators and integrase-based XOR logic gates. Successfully engineering such a reliable system not only enables a better understanding of emergent patterns, but also provides novel building blocks for biological computers."
+},
+{
+"Team":"Evry",
+"Year":2014,
+"Description":"Sponge patrol: Wipe the ocean clean!",
+"Abstract":"Our team wants to heighten awareness about environmental pollution and particularly its devastating consequences on the aquatic life. In this line of thinking we are driven to design a bioremediation tool to decrease the marine pollution and protect aquatic ecosystems. We aim at tackling elements of the main pollutant families by focusing on 5 toxic agents: Polychlorinated Biphenyls, nitrite, phenol, lead and cadmium. The bioremediation tool will be based on Pseudovibrio denitrificans, a bacterium living in symbiosis with Spongia officinalis. Our goal is to engineer the bacterium to detect, signal and degrade/capture pollutants and to bring it as new chassis in the iGEM competition. The project’s originality lies on the duo formed by Pseudovibrio denitrificans and its symbiotic sponge. Combining these two organisms allows for safe containment of the engineered strain while the extensive filtration capacity of the sponge stimulates the optimal sensing, signaling, and capturing of pollutants in water."
+},
+{
+"Team":"Exeter",
+"Year":2014,
+"Description":"Creating a modular TNT/NG bioremediator and improving commonly used tools in synthetic biology.",
+"Abstract":"Our project has two aims: To create an organism capable of effectively degrading environmental contaminants; and to create and improve synthetic tools for the iGEM database. Our first goal is to create a bacterial strain capable of degrading environmental contaminants such as TNT and Nitroglycerin. We are investigating two enzymes that can potentially perform this function, and will characterise them both in vivo and in vitro. Our second aim is to study some of the most commonly used regulators found in the iGEM Registry to assess how reliable they are, by combining them in different contexts.The reliability of such parts is essential when optimizing biological systems.In addition to this we are also testing the fluorescent protein iLOV, originally added to the Registry by Glasgow 2011. iLOV could be a useful alternative reporter to the commonly used GFP, but a lack of characterization has hindered its usage in iGEM."
+},
+{
+"Team":"Freiburg",
+"Year":2014,
+"Description":"The AcCELLerator – optogenetics in viral gene delivery",
+"Abstract":"The rapid development of synthetic biology is accompanied by an increased demand for methods that should not only enable the delivery of various genes, but also provide spatial and temporal control over gene expression. We, the iGEM team Freiburg 2014, designed a system which combines the advantages of two biotechnological approaches – the spatio-temporal resolution of optogenetics and the simplicity of gene transfer offered by viruses. In our engineered cell line light induction leads to the expression of a specific receptor serving as the entry point for the viral vector that carries the genes to be inserted. Thus our system allows specifying a subpopulation of cells by illumination at different time points to mark them as targets for viral gene transduction. The unlimited variety of gene cargos and the straightforward application of The AcCELLerator equip future iGEM teams with a fast gene delivery tool for mammalian cells."
+},
+{
+"Team":"Fudan",
+"Year":2014,
+"Description":"Tet and Cre-dependent genetic logic circuits in mammalian cells",
+"Abstract":"Cells of all organisms process numerous signals originating from the internal biological processes or from the environment to produce the appropriate cellular response.To a certain extent,the endogenous cell signal pathway is just like a logic circuit in digital system. Our team design and create a new kind of genetic logic circuit in mammalian cells based on “tet-shRNA expression system” and “Cre-tamoxifen system”, which can implement all 16 boolean logic gate functions ideally. And our team will use the circuit for creating a pathway for cell transdifferentiation and reprogramming."
+},
+{
+"Team":"Gaston Day School",
+"Year":2014,
+"Description":"Development of Tools for the Switch to Isobutanol as a Biofuel",
+"Abstract":"There are several issues in the switch from petroleum to alternative fuels. One problem is what to do with existing wastes including leaking coal ash ponds. Another issue is the efficient production of an alcohol that is effective as a fuel, easy and inexpensive to produce, and will function within the current infrastructure. This year, we improved the sensitivity of our Cadmium detector using sensitivity tuners. We are developing a strain of E. coli resistant to isobutanol and cloning GlmY, GlmZ and IlvM which are genes involved in the isobutanol production pathway . Addition of sensitivity tuners has improved the cadmium detector approximately 4-fold, from 10mM to 2.5mM, still over the federal limit. The isobutanol resistant strain of E. coli can tolerate 3 times as much isobutanol as the original strain. Finally, we have successfully isolated the glmZ coding region and have cloned it into the BioBrick vector."
+},
+{
+"Team":"Genspace",
+"Year":2014,
+"Description":"Open Lab",
+"Abstract":"The Open Lab is a key step towards democratization of synthetic biology. It is the complete set of knowledge, tools, and resources required to successfully develop a thriving community biolab, all created following open source principles. The project has four parts. 1) The Open Lab Blueprint, a website guide to launch and develop a sustainable community biolab. It includes the following components: starting up a lab, physical space, acquisition of key equipment, and efficiently implementing safety, standards and best practices, community-building, generating content and sustainability. 2) Open source equipment development in the form of a liquid handling robot, customizable with shareable protocols. 3) Set of IP-free fluorescent protein genes in open plasmid backbones to be made available to citizen scientists in the form of a starter activity kit. 4) Bioglyphics, a visual protocol design tool to lower the barrier of entry to synthetic biology practice, especially geared toward visual thinkers."
+},
+{
+"Team":"Georgia State",
+"Year":2014,
+"Description":"Utilizing the PGAPZα vector system to modify and express Mambalgin in Pichia Pastoris",
+"Abstract":"The GSU iGEM team has been working with the PGAPZα vector system in order to use the vector to artificially produce the peptide Mambalgin-1, naturally found in the African Black Mamba snake venom. This protein is unique because it has the ability to exhibit sensations comparable to morphine, but is less addictive, more efficient, and easier to obtain on a larger scale, if synthesized in a laboratory setting. By ligating the Mambalgin DNA into the PGAPZα expression system, we are able to linearize and ultimately transform the gene of interest into eukaryotic yeast, Pichia Pastoris, allowing the protein to be excreted in its most pure form. The nature of the PGAPZα and Pichia Pastoris successfully provides a smooth transition from prokaryotic to eukaryotic expression of the gene; therefore, we have chosen these vectors to effectively isolate and extract our most desired Mambalgin-1 peptide."
+},
+{
+"Team":"GeorgiaTech",
+"Year":2014,
+"Description":"#WTFrack is Up With Soluble Monooxygenase: Controlling the Situation",
+"Abstract":"Hydraulic fracturing allows us to harness Earth’s energy from natural gas, but the toxic greenhouse gas methane, released from the process, threatens the environment. Luckily, nature has provided us with a tool to reduce this toxin: the enzyme soluble monooxygenase (sMMO). This multi-complex protein is composed of Proteins A, B, and C, with Protein A itself being comprised of three-dimeric subunits α, β, and γ. While researchers have successfully expressed functional Proteins B and C in Escherichia coli, Protein A could be expressed but was nonfunctional, possibly due to incorrect subunit assembly. We hypothesize that a working protein complex may be constructed through transcriptional and translational modulation of individual sMMO genes. We will use our primer design technology to insert varying levels of efficient promoter and ribosomal binding site pairs to produce the optimal amounts of individual proteins for the formation of a fully functional enzyme-complex."
+},
+{
+"Team":"GES NCSU Raleigh NC",
+"Year":2014,
+"Description":"Mapping responsible innovation: A Do-It-Yourself, Choose-Your-Own Adventure Approach",
+"Abstract":"We propose an iterative concept mapping framework to assess ethical, legal, social, and environmental outcomes associated with releasing genetically engineered plants beyond the laboratory. We then apply this framework to The Glowing Plant, the world’s first crowd-funded genetically engineered organism. Rather than prescribing a single “responsible” course of action, we enable individual users to decide how much weight to attribute to principles such as the conservation of biodiversity, the preservation of human health and safety, the advancement of entrepreneurship and innovation, and the promotion of social equity. We also invite users to contribute additional principles, providing an iterative mechanism to help guide future decisions. By enabling users to explore the potential implications of their choices, and to compare their own preferences to others’, our model demonstrates how policy decisions depend on value judgments and encourages reflexive thinking about the social, cultural and ethical negotiations involved in technological oversight."
+},
+{
+"Team":"Gifu",
+"Year":2014,
+"Description":"Circular mRNA - the world’s longest protein",
+"Abstract":"Generally, mRNA is single-strand RNA, starting translation by binding ribosome on initiation codon, and ending by separating ribosome from mRNA. In this study, we aim to build the method of synthesizing long-repeating proteins, massive one, and to improve translation efficiency. That is, allowing ribosomes to have a semi-permanent translation mechanism by producing circular mRNA and causing a defect of termination codon. To cyclize mRNA, we can use a splicing mechanism of T4 phage. Splicing is a mechanism removing circular introns and joining in exons after transcription. Splicing is catalyzed by several base sequences at both ends of intron as a ribozyme, being subjected to nucleophilic attack from introns to exons. We would like to clone the two parts of intron to use this mechanism and cyclize mRNA, making plasmids which include a gene coding proteins between those. And, by transforming E.coli, we get world’s longest proteins."
+},
+{
+"Team":"Glasgow",
+"Year":2014,
+"Description":"Switching on the power of E.coli: a customizable recombinase switch",
+"Abstract":"A genetic recombinase switch provides irreversible, inheritable and inducible gene expression, which is of great value to the growing field of synthetic biology and iGEM in particular. We attempted to create a recombinase switch which would, in response to arabinose, switch from encoding a flagellar gene, to two genes that encode gas vesicle formation, namely gvpA and gvpC. This switch could be applied to many areas, e.g. desalination, biofuel production and drug production, by simply changing the stimulus that would cause the switch to “flip”. Computer modelling showed that swimming was detrimental to floatation. In response we created knockouts of two different flagellar genes, motA and fliC. In vivo Gvp expression is toxic to E. coli. Instead, we focused on an RFP/GFP switch, which proved that our switch construct is viable. In the future, RFP and GFP can be replaced by any two functional genes that are desirable."
+},
+{
+"Team":"Goettingen",
+"Year":2014,
+"Description":"A small change for man, a giant pain to germkind",
+"Abstract":"Our aim is to develop a diagnostic technique capable of detecting the presence of fungal pathogens in a sample collected from a patient. Briefly, our approach is as follows. Through a yeast two-hybrid assay we will select a set of peptides that show affinity towards surface proteins from different fungi (Aspergillus nidulans, A. fumigatus, Candida albicans and C. glabrata). After confirming the interaction between the surface proteins and a given peptide, we intend to attach a molecule to the peptide marker. In our project, this molecule will be a fluorescent protein, but in principle can also be an immune system activator which is then recognized by the immune cells or other chemical moiety that adds novel functionalities or increases the peptide stability."
+},
+{
+"Team":"Gothenburg",
+"Year":2014,
+"Description":"How I colored your mother",
+"Abstract":"In order to determine the replicative age of a yeast cell, researchers usually rely on direct micromanipulation of daughter cells and bud-scar counting. Given the long generation time of a cell (approx. 90 min), measuring its replicative lifespan is a laborious and time-consuming procedure. The goal of this project is to address this problem with a synthetic biology approach. We design and implement in Saccharomyces cerevisiae a synthetic gene circuit that “colors” mother cells depending on their replicative age. We use a combination of endogenous elements and Crispr/Cas-based transcription factors to induce expression of different fluorescent proteins depending on the number of budding events that the mother cells have already experienced. We foresee that the successful outcome of this project will not only facilitate yeast age determination but will also pave the way to using cell sorters in order to fully automatize the procedure."
+},
+{
+"Team":"Greensboro Aggies",
+"Year":2014,
+"Description":"BactoArt: A multicomponent, inducible expression system",
+"Abstract":"Regulated gene expression is one of the primary means by which phenotypic differences are generated among genetically identical cells (e.g., endothelial cells versus nerve cells). Nonetheless, the concept of inducible gene expression is often difficult for students to understand. To help students gain a better understanding of inducible gene expression, we developed “BactoArt”, a multicomponent, inducible expression system that allows students to visualize gene regulation in action. First, different fluorescent protein (FP) color variants (e.g., CFP, GFP, or RFP) were placed under the control of specific inducible promoters. The inducers can then be patterend onto a petri dish—using either a paintbrush or an inkjet printer—before plating BactoArt bacteria, leading to selective induction of a given FP. We simultaneously induced GFP and RFP from pXyl and pLac, respectively, and measured their fluorescence intensity over time. We believe that such hands-on activities will spark questions, leading to “teachable moments” about transcriptional regulation."
+},
+{
+"Team":"Groningen",
+"Year":2014,
+"Description":"LactoAid – A smart bandage for burn wounds",
+"Abstract":"Infections caused by Staphylococcus aureus and Pseudomonas aeruginosa often pose problems for burn wound treatments. We developed a new kind of bandage that prevents these infections and reduces the use of antibiotics, thereby lowering the risk of developing antibiotic resistance. The bandage consists of a hydrogel that contains genetically engineered Lactococcus lactis with nutrients. The engineered strain of L. lactis detects the quorum sensing molecules of the two pathogens in the wound and subsequently produces the antimicrobial nisin as well as some other Infection-Preventing-Molecules (IPMs). These IPMs are the anti-biofilm protein Dispersin B and the quorum quenching protein AHLase. The gel is placed between two layers, a top layer to allow diffusion of gases and a bottom layer to contain the bacteria within the bandage. Hydrating the gel by breaking adjacent water pockets initiates the growth of the bacteria, thereby activating the bandage."
+},
+{
+"Team":"Hannover",
+"Year":2014,
+"Description":"Plant against – Removing heavy metals from nature",
+"Abstract":"Plant against: Our title reveals the main organism of our project: plants. We designed a protein for plants, Top4-Metal Binding Protein (T4-MBP), composed of four different domains for the binding of heavy metals. We have chosen the domains from different organisms considering heavy metals with a global relevance: copper, arsenic, zinc and cadmium. Our goal is to produce the T4-MBP in plants, where it will be transported out of the plant cells to attach itself to the cellulose. The binding of the heavy metals via plants is supposed to work in water or on ground to clean up many different areas containing heavy metals. Furthermore we have other fields of application, like the purification of drinking water. With our project we want to provide the world an easy way to remove heavy metals where chemical solutions are lacking."
+},
+{
+"Team":"Harrisburg NBT",
+"Year":2014,
+"Description":"PUPS- Paper Utilizing Pesticide Sensors",
+"Abstract":"Pesticide pollution is an unfortunately typical problem found in agricultural regions around the world. Developing regions that rely heavily on agriculture, but have less regulations related to pesticide use tend to suffer the most from pesticide pollution. Organophosphates (OP) represent a large class of toxic pesticides used heavily in these areas. We have designed novel devices to detect these toxic pollutants in waterways called PUPS, or Paper Utilizing Pesticide Sensors. These devices are paper-based with 3D printed shells, making them very cost effective for use in poor areas worldwide. The PUPS will utilize a fusion protein that will be produced in E. coli to degrade organophosphates into 4-nitrophenol (4NP), which OPs degrade into naturally over time. The 4NP will then be reduced in order to electrochemically measure the 4NP concentration at cheap, graphite electrodes. These reactions all occur within cellulose paper, which drives the microfluidic movement of the samples."
+},
+{
+"Team":"Harvard BioDesign",
+"Year":2014,
+"Description":"A robust information encoding and display system in E.coli biofilms for use in biosensors",
+"Abstract":"E. coli cells naturally secrete a protein called curli into their extracellular matrix that self-assembles into ordered, linear, amyloid fibers important for the structural integrity of the biofilm. We have designed an information encoding and storage system in the E.coli curli biofilm network. In our system, bacteria are engineered to produce a mixture of curli subunits that can later be read out as information. Our system can be put under the control of any environmentally sensitive promoter, facilitating the practicality of using biosensors in the field. Other potential applications include cryptography and nanoscale patterning. This system represents a novel method by which information can be stored in a scaleable nanomaterial with functional potential. Living materials offer an advantage over classical materials because they are adaptable, versatile, and can self-pattern complex architectures."
+},
+{
+"Team":"Heidelberg",
+"Year":2014,
+"Description":"The Ring of Fire",
+"Abstract":"Biology works with networks of interacting proteins and controlling their functions is fundamental to Synthetic Biology. Conventionally, control depends on gene expression, however modifications made after expression enable fast and precise regulation. Our team has designed a universal toolbox for modifying proteins post-translationally utilising inteins and sortases. In the natural process of protein splicing auto-catalytic inteins excises themself leaving the flanking chains reconnected. Similarly, sortases identify, cut and rejoin protein sequences. Comprising a variety of standardised parts our toolbox can specifically change whole amino-acid sequences therefore regulating proteins via assembly or protein cleavage. Very curiously, these methods enable circularisation of enzymes rendering them thermodynamically stable and resistant to exoproteases, which will be applicable in biotechnological procedures requiring high temperatures. Our software selects the best technique for circularisation and a distributed computing platform facilitates the calculations. Taken together we provide a new foundational advance introducing full post-translational modification to Synthetic Biology."
+},
+{
+"Team":"Hendrix Arkansas",
+"Year":2014,
+"Description":"Using synthetic biology to engineer a visible alkane-reporter strain of Yarrowia lipolytica yeast",
+"Abstract":"Cancerous cells are known to give off volatile compounds (alkanes) that can be detected by trained dogs. Our goal is to engineer a strain of Yarrowia lipolytica, which is capable of detecting alkanes, to turn color in the presence of these volatile compounds. We hope that we can use this yeast to detect melanoma cheaply and non-invasively (perhaps in a cancer detecting band-aid). To achieve our goal, we will build a reporter construct that uses an alkane sensitive promoter to drive the expression of a blue chromoprotein from the coral Acropora millepora which should cause the yeast to turn blue in the presence of alkanes. Our parts include an alkane response element (3xARE1), a leu minimal promoter, our reporter gene (blue chromoprotein), and a terminator (XPR2). Once the reporter construct is assembled, we will clone it into a Yarrowia lipolytica shuttle vector and integrate it into the yeast genome."
+},
+{
+"Team":"HFUT CHINA",
+"Year":2014,
+"Description":"BioFunctional Designer",
+"Abstract":"With the increase of influence which belongs to iGEM Competition, a growing number of teams involved in the game. Each team brainstorming to design many valuable model. There are a significant contribution to the field of synthetic biology. But it is a hard thing for people to understand the wide variety of models. Therefore , it is necessary to find solution to understand the integral information of the various models through a small part of it. Sometimes though people know the specific composition of the model, but its function is unclear. We are committed to the development of a software. It can help people to solve the above-mentioned problem in the first time. It could recommend corresponding parts should be used for different functions team proposed."
+},
+{
+"Team":"HIT-Harbin",
+"Year":2014,
+"Description":"Green Yeast",
+"Abstract":"Dioxins are commonly regarded as highly toxic compounds that are environmental pollutants and persistent organic pollutants. Its deleterious hazards intensify with the odorless, colorless and fat- soluble properties, which enable dioxins to accumulate in vivo thus threaten almost the whole biosphere. To detect dioxins blisteringly, we have constructed device for rapid detection of dioxins inside yeast. We utilized associability between the gene for testing dioxins of MOUSE as receptor and dioxins as signal, together with the regulation conducted by lexA operator to downstream promoters so that the fusion protein combined bydioxin receptor and lexA can induce downstream gene with the presence of dioxins. Eventually, we can achieve our goal of detecting dioxins rapidly through the system of positive feedback of fluorescence. We additionally design a secretive gather part by emulsifying protein to add the soluble ability of dioxins and anchoring the dioxin degradation enzyme on the surface of the yeast."
+},
+{
+"Team":"HNU China",
+"Year":2014,
+"Description":"Alcoholic Miner: Iron Sensitive Absorbing Yeast with Optogenetic Apoptosis Biosafety System",
+"Abstract":"As far as the bronze age, our ancestors began to extract valuable metal from the mineral, with the combined process of chemical reaction and high temperature treatment, using quite a lot energy.When this ancient industry comes to the modern time, we would like to utilize microorganizms to extract metal with the tool of synthetic biology. Our microbial miner briefly consists of two systems, iron sensitive absorbing system and optogenetic apoptosis system, the last of which is designed for the biosafety reason. These two yeast systems combined to work together getting iron."
+},
+{
+"Team":"HokkaidoU Japan",
+"Year":2014,
+"Description":"RNA in love ~ Ms. asRNA just wants be a perfect one for Mr. mRNA ~",
+"Abstract":"Utilization of anti-sence RNA (asRNA) became more popular method for knockdown of target gene expression. However, it is still difficult to create a perfect asRNA structure because it is affected by several factors, just like love. Ms. asRNA is always seeking to succeed in love with Mr. mRNA. iGEM HokkaidoU plays a role as Cupid through advising her to be a perfect structure as asRNA. We made an easy and useful protocol, which enables us to design standarized BioBrick parts expressing asRNA. Using this protocol, anyone can easily became Cupids. These asRNAs contain paired-termini (PT) structure, which flanks asRNA sequence, and stabilizes asRNA part through forming “stem-loop structure” in E.coli cells (N. Nakashima et al. 2006). We believe that our protocol will largely contribute to make easier for utilizing asRNA and help many researchers, including iGEMers. Let’s lead Ms. asRNA to success!"
+},
+{
+"Team":"Hong Kong-CUHK",
+"Year":2014,
+"Description":"ABCDE (AzotoBacter vinelandii: from Carbon Dioxide to methane Energy)",
+"Abstract":"Methane is a multifunctional gas that is used as fuel and an important carbon source. It is also used to make bio-degradable plastic. We aim at converting carbon dioxide and carbonate, which are excessive to the ecosystem, into methane. An engineered nitrogenase (α-70Ala, α-195Gln) in Azotobacter vinelandii has been shown to have the ability of reducing carbon dioxide and carbonate into methane and other carbon compound. However, the carbon fixation process consumes a large numbers of protons and thus decreases the reaction rate. We propose to co-express hydrogenase III from Aquifex aeolicus to speed up the carbon fixation step in A. vinelandii."
+},
+{
+"Team":"Hong Kong HKU",
+"Year":2014,
+"Description":"A Flexible Strategy for Cytoplasmic Compartmentalization in Bacteria",
+"Abstract":"It is well-known that prokaryotes do not have cytoplasmic compartmentalization. However, certain bacteria possess gene clusters that encodes five to six small, structural proteins that self-assembles into a hollow, icosahedral-like organelles called Bacterial Micro-Compartments (BMCs). We constructed a flexible plasmid with various features that allows convenient, customized functionalization of these microcompartments, both externally and internally. As a proof-of-principle project, we also attempted to purify the neo-functionalized BMCs and test their biological activity both in vivo and in vitro. Based on our generalized system, there would be more interest in utilizing this remarkable evolutionary product for multiple biotechnological applications, from solving environmental issues, to medicinal applications, or even metabolic engineering and novel scientific research tools."
+},
+{
+"Team":"Hong Kong HKUST",
+"Year":2014,
+"Description":"Finding Pneumo",
+"Abstract":"Streptococcus pneumoniae is responsible for approximately 1.6 million deaths every year mostly in developing countries where vaccination is unaffordable. To provide an affordable solution to combat pneumococcal diseases, we are engineering an E. coli “Pneumosensor”, that will work inside an in vitro diagnostic device. Through this cheaper and easier diagnosis method, people can prepare themselves better against the transmission and adversity of S. pneumoniae. Pneumosensor has a rewired comCDE signal transduction pathway native to S. pneumoniae that detects autoinducer molecules released specifically by S. pneumoniae. It is also equipped with a new promoter for the specific and tight regulation of target gene expression in E. coli. In addition, the team is documenting and characterizing existing CR-TA riboregulators for post-transcriptional regulation of gene expression. Our work will provide information for other iGEM teams to incorporate this tuning tool into their project design."
+},
+{
+"Team":"HUST-Innovators",
+"Year":2014,
+"Description":"Using the third generation sequencing technology in EPA production",
+"Abstract":"Using the conception of module, We are trying to use the third generation sequencing to build new biobricks from some unsequncing species.This is a novel idea to combine the bioinformatics and the synthetic biology. We improve the algorithm to let the sequencing be quicker and cheaper and the output of our software includes both genome and some useful biobricks. Then we apply this software for the Thraustochytrids which has not been sequenced yet.By analysising the output of the software we locate the sequence which the Thraustochytrids use to produce EPA then we use this sequence and assemble them as biobricks and transfer them into yeast which have a mechanism that control a set of particular enzyme by the concentration of lactose .So the production of EPA can be controled by lactose."
+},
+{
+"Team":"HUST-China",
+"Year":2014,
+"Description":"Warlord E.CaoMengde - a tale of 3 pollutants treatment",
+"Abstract":"As a result of industrialization, heavy metal pollution has become a serious problem in the world and copper can be extremely toxic to human body. The excessive cellular amount of Cu ions can readily interact with oxygen, resulting in the generation of hydroxyl radicals which lead to harm. The typical disease caused by copper is called Wilson Disease, which has become a world concern. A rotating biological contactor (RBC) is a biofilm-based reactor technology vwidely used for wastewater treatment. In our program, we combine heavy metal meditation with RBC and developed a toolkit gathering Cu ions from polluted water, degrading the cyanide, detoxifying the fluoride and suggesting whether the water is safety in terms of copper amount. Our bacteria stands out with the character of accumulating everything in favor and eliminating things with hostility, which is similar to a famous Chinese historical warlord called Cao Mengde."
+},
+{
+"Team":"HZAU-China",
+"Year":2014,
+"Description":"Rewirable Circuit: an elegant means of systems integration",
+"Abstract":"Standardization is one of the greatest features in synthetic biology. However, synthetic biologists meet obstacles when combining parts and modules to create more sophisticated systems using the standardization principle. In our project, we created some modules to reintroduce the conception of “adaptability”, which is one intrinsic characteristic of natural living systems. Processing modules can alter the way they process information in order to adapt to environmental changes. The circuit we designed can rewire its connections between parts and devices to implement multiple functions with the help of site-specific recombination systems. Host overload and unexpected interplay between modules are prevented in our design. Besides, we designed a post-transcriptional control in the input module and an RNA-level fluorescence in the output module to make the system work effectively. Our design may lead to a forward step towards system integration in synthetic biology."
+},
+{
+"Team":"IIT Delhi",
+"Year":2014,
+"Description":"Eco.Coli : Eco-Friendly Reduction of Harmful Oxides from Automobiles and Industrial Emissions",
+"Abstract":"The effects Global Warming has attracted the attention of the major stake holders of the world who believe that the need of the hour is to combat the levels of the toxic greenhouse gases emitted. With increase in the number of automobiles and industries, the emission of harmful greenhouse gases mainly nitrogen and sulphur oxides increases leading to global warming. We plan to build a model involving synthetically engineered E.coli, which is compatible to all the possible exhaust mechanism due to its scalability. We genetically engineered NrfA , Cys1 and SQR genes in E.coli which would help in converting SOx and NOx from the exhaust gases of automobiles and chimneys of industries to harmless compounds.Our model is optimized for the efficiency of the reduction of nitrogen and sulphur oxides without compromising on the growth and manufacturing productivity of the industries."
+},
+{
+"Team":"Imperial",
+"Year":2014,
+"Description":"Manufacture of Bacterial Cellulose Biomaterials: Towards Tailor-Made Biofilters",
+"Abstract":"Bacterial cellulose is a natural biomaterial that is of interest in many fields due to its high purity compared with plant-derived cellulose. We are optimising cellulose biosynthesis in Gluconacetobacter xylinum, transferring the system to E. coli, and functionalising the material using proteins in order to expand its properties and applications. Bacterial cellulose has seen use in clothing and health foods, but we develop its application to the global issue of water purification. Rising demand for limited freshwater supplies will lead to more than half of the global population suffering severe water stress by 2030. Improved filtration techniques would help relieve this problem. The inherent porosity of cellulose and our synthetic attachment of contaminant-specific binding and catabolic proteins make for a flexible, modular water filter. Our manufactured biomaterial would augment water recycling and reclamation on local and industrial scales, helping to alleviate global water stress."
+},
+{
+"Team":"INSA-Lyon",
+"Year":2014,
+"Description":"CurLy’on",
+"Abstract":"The INSA-Lyon team is developping an E. coli-based platform as an alternative depollution method for metal contamination in water using an amyloid-display system for surface-functionalization, called CurLy’On. As far as France is concerned, drinkable water contamination from the metal pipes is a real issue. Indeed, the cost is estimated to twenty billion euros to fully replace the existing infrastructure. Using our system based on nano-sponge surfaces for water purification, we propose to extend this concept into a cheap bacterial filter as a solution. Indeed, the use of surface-specific protein particularly benefits the biotechnology research field, and extensively the synthetic biology field, in depollution alternative strategies but also in the medical field by improving the dialysis’ filter specificty on various metals for renal-insufficient patients."
+},
+{
+"Team":"ITB Indonesia",
+"Year":2014,
+"Description":"SynBIGreen (Synthetic Biology Indonesia Go Green)",
+"Abstract":"PET or commonly known as plastic has been widely used in various application. We can’t deny that plastic give us a lot of benefit, though overproduction of plastic could give serious impact for the environment if not treated properly. The total of global plastic is estimated to exceed 24.39 million tons in 2015; therefore, appropriate treatment is necessary. To solve the problem, we try to degrade plastic using synthetic bacteria. We establish ompA protein fused with LC-Cutinase in Escherichia coli BL21 thus exposing the degrading enzymes on the surface membrane of bacteria. We also construct a cassette comprised of glycoaldehyde reductase and glycoaldehyde dehydrogenase which responsible in metabolising ethylene glycol as byproduct of degradation. We use constitutive promoter for both construct, thus making it necessary to create a modul of reporter and self regulatory to maintain system efficiency and minimizing severe cytoplasmic stress from formation of inclusion body aggregate."
+},
+{
+"Team":"ITESM-CEM",
+"Year":2014,
+"Description":"Medical Biorremediation: An alternative treatment for atherosclerosis",
+"Abstract":"The biochemical development of atherosclerosis is complex, and involves a variety of factors; it is intimately associated with hypercholesterolemia, smoking, obesity, and diabetes mellitus, among other conditions. One of the most accepted theories explaining its origin suggests that it is triggered by the chemical modifications of Low Density Lipoproteins (LDL), which are susceptible to oxdiations; it is believed that these oxidized products accumulate on the artery walls (tunica intima), generating an inflammatory process that will ultimately cause the development of atheroma plaques. LDL products are being oxidized by the interaction with Reactive Oxygen Species in the bloodstream, this can occur either within fatty acids or sterols, such as 7-ketocholesterol, one of the most common reaction products. We pretend to develop a new synthetic model capable of degrading the oxidized form of cholesterol by using gene therapy."
+},
+{
+"Team":"ITESM-Guadalajara",
+"Year":2014,
+"Description":"Development of a novel ecological, economic and biotechnological production process of Chitosan in Mexico",
+"Abstract":"Our project, “Kitosan Factory” (KF), consists in the production of a valuable biopolymer called Chitosan from the shrimp shell wastes using an ecological, economical and biotechnological process. Chitosan has a global market value of $20 billion USD and it is widely used in pharmaceutical, food and cosmetic industries, among many others, due to its biodegradability, non-toxicity and biocompatibility properties. The traditional extraction method involves the use of acids and alkalis that makes the process expensive, highly pollutant and non-standardized; that’s why we propose a novel method using B. subtilis and a modified E. coli, which contains 6 enzymes capable of cutting and deacetylating chitin for the generation of chitosan. This way, KF provides tools for the innovation and development of new biotechnological products, the creation of jobs, the solution of an existing waste disposal problem and the education of people about the advantages of biotechnology in Mexico."
+},
+{
+"Team":"IvyTech SouthBend IN",
+"Year":2014,
+"Description":"Detection of Environmental Coliphage through Alpha-Complementation of Beta-Galactosidase in a Fast-Acting Bacterial-Based Biosensor.",
+"Abstract":"An assay for coliphage detection has been developed which employs the release of the host indicator cell beta-galactosidase enzyme activity by lytic coliphage and the conversion of a colorimetric substrate, shortening the APHA time to 3 hrs. We’re engineering cell lines containing the gene fragments of LacZalpha and will use an E.coli cell line with the M15 mutation expressing the omega fragment of Beta-galactosidase. We’re introducing a cassette of coliphage cell lysis genes under the control of a coliphage promoter to accelerate the enzyme fragment release, further reducing test time. Alternative to the enzymatic read-out we are exploring a microfluidic system to detect the lysis of the cells. Our goal is to design a fast-acting hand-held coliphage biosensor device that can be used by someone without any special technical expertise. Our device is useful in rapidly reporting the contamination of recreational waters or assuring drinkable water in developing nations."
+},
+{
+"Team":"Jilin China",
+"Year":2014,
+"Description":"The Intelligent Scout and Sniper for Freshwater Toxin",
+"Abstract":" Microcystin LR, one increasingly common toxin in freshwater, affects the liver as hepatotoxin, causing nausea, diarrhea, vomiting and even acute liver failure when ingested.Of all types of Microcystin LR , MC-LR has the most deleterious influence on the environment as well as human beings. Therefore, we strives to explore simple methods for detection of this toxin and finding ways to alleviate water pollution caused by this toxin. During algae bloom break out, a strain of Pseudomonas expresses a series of proteins, named Mlr, that could decompose algal toxin.we use E.coli instead of Pesudomonas to improve the expression of Mlr proteins and constructs a system to detect the contents of toxin in water and early alarm the algal bloom. If Microsystin LR is our enemy that poisons aquatic organisms and human body, then the engineering bacteria act as the intelligent scout and sniper for this freshwater toxin."
+},
+{
+"Team":"KAIT JAPAN",
+"Year":2014,
+"Description":"Immune Yeast",
+"Abstract":"Acquired immune system is one of two main immunity strategies in vertebrates. In this system, helper T cells play a key role. Th1 cells and Th2 cells keep balance mutually, and two cells usually control immune response. When this balance collapses and the Th2 become predominan, IL-5 is secreted excessively from Th2, and eosonophil, basophil, and mast cells are activated by IL-5. These activated cells secrete inflammatory materials that cause allergic symptoms such as bronchial asthma and atopic dermatitis. On the other hand, by stimulation of IL-12, naive T cell differentiates into Th1 cell. The differentiated Th1 cell alleviates allergic symptoms. We though that it is possible to improve allergic symptoms by decreasing IL-5 and increasing IL-12. We try to make IL-5 independent expression system in yeast by focusing on ligand independent dimerization of IL-5 receptor."
+},
+{
+"Team":"Kent",
+"Year":2014,
+"Description":"The Biosynthesis of Fragrant Terpenoids in E. coli - Sweet scents. Nothing cheesy",
+"Abstract":"Ecological systems are constantly threatened with destruction due to human practices such as deforestation and excessive over cropping to create depleting supplies for the perfume production industry. This dilemma is what we aim to tackle in our project. By engineering E. coli to produce scent compounds that are hard to come across naturally, we aim to make perfume accessible for all in a sustainable manner. This synthetic biology approach can be used to create a database of scents that can be ordered to consumer demand. By using E. coli to generate these compounds, we aim to reduce the cost of these scents and improve yield in a more environmentally sustainable and less destructive manner. In summary, our BioBricks will be aimed at the production of a class of scent compounds called terpenoids, which will provide a proof of concept for future scent production.."
+},
+{
+"Team":"KIT-Kyoto",
+"Year":2014,
+"Description":"E.motion: Dawn of the New Generation BioArt",
+"Abstract":"We infuse dynamic art and design into E.coli and Saccharomyces cerevisiae to create new inspiration. It is not just static, garden-variety of drawings with fluorescent proteins such as GFP, RFP or YFP, you have seen somewhere. In front of you are fragrance by monoterpene and motion of organisms in perfect combination. We even invite insects to perform around our artwork; monoterpene’s repellent effect certainly affects insects’ behavior. It is a BioArt of future generation that gratifies your senses. Our artwork will wow you and wake up your desire to express yourself in the form of art. You may think E.coli is stinky or poopy. No! With the power of synthetic biology, it can be aromatic! Our proposition: synthetic biology inspires everybody."
+},
+{
+"Team":"Korea U Seoul",
+"Year":2014,
+"Description":"Protein whip platform",
+"Abstract":"Our project is to construct a novel “protein whip” platform, with which we can make Corynebacterium glutamicum to express other corynebacterium’s pili structure comprised of chains of our interested protein. As our first try, we decided to make pili made out of green fluorescence proteins (GFP); we substituted SpaA protein, one of the surface proteins in the pili gene cluster, into GFP, and transformed a vector containing the modified pili gene cluster into a C. glutamicum. “protein whip” platform has many practical applications. For example, pili made out of an enzyme, enzyme whip will enable the reaction to take place with high efficiency. Biofilms made of bacteria that express pili comprised of histidine or cysteine that readily bind to heavy metals may be utilized to purify water contaminated with heavy metals. By using C. glutamicum instead of Escherichia coli, our project contributes to expanding model organisms used in synthetic biology."
+},
+{
+"Team":"Kyoto",
+"Year":2014,
+"Description":"DMS SYNTHESIS AND MAGNETOSOME FORMATION",
+"Abstract":"This year, we have two projects. The first project is DMS (dimethylsulfide) synthesis. DMS is known to be a precursor of the cloud condensation nucleus. Some researchers say that DMS greatly affects the climate. Although the existing researches have already lined up the candidate genes of the DMS biosynthesis pathway, most of them are still unconfirmed. Therefore, we tried to confirm them by introducing 5 candidate genes in Fragilariopsis cylindrus; a diatom, into Escherichia coli. The second project is magnetosome formation. Magnetosome is a specific organelle in magnetotactic bacteria. Although many researchers have focused on it for its unique feature; magnetosome detect magnetic force, they have discovered only magnetotactic bacteria to have this ability so far. So we tried to form the Magnetosome in E. coli by introducing 4 operons which has been lined up recently as the sufficient genes to make magnetosome in Magnetospirillum gryphiswaldense."
+},
+{
+"Team":"LA Biohackers",
+"Year":2014,
+"Description":"Boot up a Genome",
+"Abstract":"We are using Bacillus subtilus as a backbone to incorporate the entire genome of Streptococcus thermophilus. Once incorporated, we use the cre/lox recombination system to remove the Bacillus subtilus genome so only the Streptococcus thermophilus genome remains. This demonstrates the use of Bacillus subtilus as an ideal chassis to boot up an artificial genome."
+},
+{
+"Team":"Lethbridge",
+"Year":2014,
+"Description":"Nomadocytes: Engineering Microglia for CNS Cell Therapy",
+"Abstract":"Stroke and neurodegenerative disease collectively cost the Canadian medical system millions of dollars annually while effective neural regenerative therapies remain elusive. Astrogliosis, a cellular response to such neural insults, leads to the formation of a non-functional “glial scar” and an inhibitory cellular environment that impedes neural regrowth and recovery. Our project involves engineering microglia, the mobile immune cells of the brain, to package and deliver a therapeutic plasmid specifically to central nervous system cells. The plasmid encodes a reprogramming factor that converts reactive astrocytes into new neurons, helping to restore the functional neuronal population and permit regrowth of damaged connections. We have also developed a novel plasmid selection system that bypasses antibiotic-based selection to reduce the size of the reprogramming plasmid. This project has the potential to provide a novel, non-invasive rehabilitative therapy that could lead to significantly improved functional recovery following brain injury or disease onset."
+},
+{
+"Team":"LIKA-CESAR-Brasil",
+"Year":2014,
+"Description":"ColiKiller for BreastBotSensor",
+"Abstract":"The LIKA- CESAR BRAZIL proposes the development of a biosensor for the detection of breast cancer with the help of robotics. The idea is to build a robotic system linked to genetic engineering capable of processing and prepare small samples of blood in an automated manner. For this our team, will generate useful BioBriks records and parts for possible future insertions in the plates. This system will be coupled to biosensors capable of detecting breast cancer in its earliest stage, where the chances of the patient having an accurate diagnosis and treatment guidance are very high. The automation of the entire process, together with the creation of a specific biosensor for breast cancer, will result in a future decrease in deaths from the disease, due to a more rapid and effective treatment."
+},
+{
+"Team":"Linkoping Sweden",
+"Year":2014,
+"Description":"AllergenSAFE: A Sensitive and Accurate Food Evaluation",
+"Abstract":"The goal of our project is to use an antibody in combination with fluorescent probes to detect Ara h1, a major allergen protein in peanut. We use a detector which is divided into two components, one chemical and one physical. The chemical component is composed of three potential parts: one antibody complex linked to Fluorescein isothiocyanate (FITC), one epitope complex linked to RFP, and finally Ara h1. These are potential parts in the sense that the system will always contain the first two parts (antibody and epitope complexes), but will only contain the third part, Ara h1, if the inserted food sample has been contaminated with peanut protein. The physical component, the biosensor system, is composed of a box containing sensors necessary to detect fluorescence and any eventual changes in fluorescence. This information is processed by a microprocessor to give a color indication, correlated to the changes in fluorescence."
+},
+{
+"Team":"LMU-Munich",
+"Year":2014,
+"Description":"„BaKillus“ – Engineering a pathogen-hunting microbe",
+"Abstract":"Increasing bacterial resistance to classical antibiotics remains a serious threat and urges the development of novel pathogen-killing strategies. Exploiting bacterial communication mechanisms such as quorum sensing is a promising strategy to specifically target certain pathogens. The major aim of this project is the introduction of a genetic circuit enabling Bacillus subtilis to actively detect, attach to, and eventually kill Staphylococcus aureus and Streptococcus pneumoniae. Initially, we will introduce the autoinducer-sensing two-component systems of S. aureus and S. pneumoniae into B. subtilis to create a pathogen-detecting strain. By utilizing quorum sensing-dependent promoters, we will then trigger pathogen-killing strategies like the production of antimicrobial peptides or biofilm degradation. As a safety measure a delayed suicide-switch guarantees non-persistence of genetically modified B. subtilis in the absence of pathogens. We envision the use of BaKillus as a smart, cheap and simple-to-use medical device for diagnostics and targeted treatment of multiresistant superbugs."
+},
+{
+"Team":"London BioHackspace",
+"Year":2014,
+"Description":"JuicyPrint, a 3D printer using bacteria to print cellulose forms on demand",
+"Abstract":"The London Biohackspace is a non-profit community biology lab where a diverse group of experts and newcomers alike create inventive projects. Our 2014 iGEM project is JuicyPrint, a 3D printer that is fed with fruit juice to print on demand 3D structures of bacterial cellulose. JuicyPrint has diverse uses across fields ranging from tissue engineering to textile design and experimental arts. JuicyPrint relies on a strain of the extra-cellular cellulose producing bacteria, Gluconacetobacter hansenii. The engineered strain is light sensitive, and grows on easily obtainable fruit juice. Our project uses Cph8 to insert a light dependent transcription regulation pathway into G.hansenii to control the transcription of dgc1, a gene necessary for the production of extracellular cellulose in G.hansenii."
+},
+{
+"Team":"LZU-China",
+"Year":2014,
+"Description":"A Novel Microbial Fuel Cell System That Can Measure Substrates Concentrations Using Genetic Engineered Bacteria",
+"Abstract":"Microbial Fuel Cells (MFCs) which can convert contaminants in wastewaters into energy is an ideal approach to solve both pollution problem and energy crisis. However, MFCs is hard to determine the contaminants concentrations which is a major drawback for MFCs applications. We found that the electricity produced by MFCs was somewhat related to the substrates concentrations such as P-nitrophenol (PNP) in anode or Chromium (VI) in cathode. Then a novel MFC system was designed. For anode strain, we’ve cloned a PNP sensor sequence and a riboflavin into Escherichia coli. The recombinants is able to detect PNP and produce riboflavin to boost electrical generation when co-cultured with Shewanella oneidensis. In the cathode, gene codes chromate (VI) reductase Yief was cloned into E.coli. The stability of MFCs has been improved and the electricity generated was correlated with the substrates. Moreover, we’ve designed a program which can monitor the contaminants concentrations in MFCs."
+},
+{
+"Team":"Macquarie Australia",
+"Year":2014,
+"Description":"The Green Machine: Re-engineering the chlorophyll biosynthetic pathway in E. coli",
+"Abstract":"Photosynthesis is a key biological pathway that uses the energy from sunlight to convert water and carbon dioxide into ATP, glucose and oxygen. Chlorophyll is a green pigment that facilitates energy production in photosynthetic organisms. Our goal is to engineer 13 genes of the chlorophyll biosynthetic pathway (CBP) from Chlamydomonas reinhardtii to be expressed in E. coli. Although the CBP has been well characterised by biologists there has been no success in reproducing the process in a non-photosynthetic host. Successful production of chlorophyll in a bacterial host is the first step towards the synthetic construction of Photosystem II leading to industrial production of Hydrogen gas for energy production."
+},
+{
+"Team":"Manchester",
+"Year":2014,
+"Description":"Battling Against Obesity",
+"Abstract":"Obesity is a growing problem in today’s society. Our project aims to engineer a novel treatment for obesity. By modifying the natural CRP pathway, we will turn the commensal bacterium Escherichia E.coli Nissle 1917 into a “sugar sponge” that will absorb excess carbohydrates before they can be taken up in the human intestines. Our engineered bacteria is aimed at obese people who have tried other approaches to weight loss, but have failed to see any results. Other uses could include patients who need to lose weight before surgery. The bacteria would be delivered in the form of a pill or yogurt drink. Our project will include an in-depth sociological analysis of modern attitudes to obesity based on research and data collected from surveys, exploring public opinion regarding body weight as well as synthetic biology and genetic modification. We have used the results to direct our engineering strategies."
+},
+{
+"Team":"Marburg",
+"Year":2014,
+"Description":"SURF - Synthetic Units for Redirecting Functionalities",
+"Abstract":"Life’s success story on earth is largely based on the rewiring of a rather limited set of naturally occurring protein modules. We systematically analyzed the structural evolution of certain protein families by a computational approach, and deduced design principles for the creation of artificial scaffolds and catalysts with individualized properties. By this approach, we enable exchangeable and extendable protein libraries that carry synergistic functionalities. Our conceptual approach is challenged by the creation of chimeric proteins and their functional assessment as relevant biotechnological and biomedical applications for the sake of humankind."
+},
+{
+"Team":"Melbourne",
+"Year":2014,
+"Description":"Biosynthesis of star peptides in E. coli",
+"Abstract":"Star-shaped peptides are a promising biomaterial being proposed for use in nanomedicine. While star peptides have conventionally been synthesised in vitro, the University of Melbourne iGEM team aims to use the peptide-synthesis machinery of E. coli to produce these peptides in vivo. To this end, star peptide precursors will be expressed and purified from E. coli and then reacted to form stars. The arms of these stars may be functionalised with various biomacromolecules, including peptides and proteins. By incorporating various molecules in the star arms (e.g. antimicrobial peptides or anticancer drugs), the star peptides may be applied in a variety of biomedical contexts as drug delivery vehicles or macromolecular linkers. The project notably blends synthetic biology and synthetic chemistry, contributing to both fields by developing a bacterial platform technology for peptide-based nanoparticles."
+},
+{
+"Team":"METU Turkey",
+"Year":2014,
+"Description":"Degredo PETronum",
+"Abstract":"The usage of Polyethylene terephthalate (PET) like plastic bottles is one of the biggest problem of our era. Many plastic bottles are not reusable. Some tougher, reusable plastic bottles may cause cancer. The main disadvantage of plastic bottles is that so many of them end up in landfills instead of being recycled. It takes hundreds of years for plastic bottles to biodegrade, and the degrading process emits toxic chemicals into the air. We may alter the destiny of plastic in useful way. Our project aims to keep the environment clean with the degradation of PET to pyruvate by E. coli. With this project, while the environment will be cleaned from PET, the E. coli would add pyruvate to the cell cycle and use it as a new energy source for itself. We will biodegrade PET to Catechol. Then catechol to 2-hydroxymuconate resulting in pyruvate."
+},
+{
+"Team":"Michigan Software",
+"Year":2014,
+"Description":"ProtoCat: Increasing Reproducibility Through Protocol Sharing And Review",
+"Abstract":"Choosing apt and reliable protocols for new experiments is a problem that wet labs routinely face due to the difficulty in anticipating which protocols will produce the best results. Experimental practices may differ immensely across laboratories and precise details of these practices may be lost or forgotten as skilled faculty or students leave the lab to pursue other endeavors. Furthermore, there are few well-defined protocols that are generally agreed upon by the scientific community, in part due to the lack of a system that can supply a measure of a protocol’s acceptance. In order to address these problems, we set out to build a database that integrates a crowdsourced ratings and comments system to serve as a protocol curator that enables wet lab investigators to compare various protocol efficacies, quantify a protocol’s acceptance within the scientific community, and provide an avenue through which experiential knowledge can be communicated."
+},
+{
+"Team":"Missouri Miners",
+"Year":2014,
+"Description":"Remediation of Coal Flue Gasses",
+"Abstract":"The goal of this year’s project is to genetically modify Cyanothece to allow it to fix all forms of nitrogen oxide pollutants in coal flue gases. Coal is one of the primary sources of global energy and produces carbon dioxide and nitrogen oxide pollutants, among others, which contribute to global warming and acid rain formation. Fixing nitrogen through Cyanothece has another benefit besides reducing pollution; the end products are ammonia compounds which are a major component of fertilizer. We hope this will allow power companies to offset some of the costs of cleaning their emissions by selling the ammonia products to be made into fertilizer. We will be isolating the nitrogen fixing genes and adding them to the BioBricks Parts Registry for the Jamboree."
+},
+{
+"Team":"Minnesota",
+"Year":2014,
+"Description":"Mntallica: Engineering Bacteria for Mercury and Heavy Metal Bioremediation",
+"Abstract":"Mercury is a neurotoxic heavy metal with the ability to biomagnify, and is a significant issue in public and environmental health worldwide. Rising levels of mercury due to mining activities, industrial catalysts, agricultural fungicides, and the burning of fossil fuels has resulted in the pollution of many ecosystems and water reservoirs. Cleanup of mercury contamination using current technology is either not feasible or incredibly costly. This study describes the engineering of recombinant bacteria that can facilitate the bioremediation of the neurotoxic methylmercury and mercury ions into less toxic form, and reduce other heavy metals. This synthetic microbe was encapsulated within a cost-effective, scalable water filtering device. Device employment could rigorously change the practices used in mercury decontamination efforts by switching to biological rather than chemical processes. Furthermore, this technology can be applied towards bioremediation and biosensing of various heavy metals and organic toxins in the environment."
+},
+{
+"Team":"MIT",
+"Year":2014,
+"Description":"The Diagnosis and Treatment of Alzheimer’s Disease",
+"Abstract":"Alzheimer’s disease is a neurodegenerative disease that is characterized by the aggregation of beta-amyloid oligomers in the brain. These cause neuron death and disrupt the proper functioning of surviving neurons. Despite the severity of the disease, Alzheimer’s diagnosis and treatment are limited to post-symptomatic psychological methods and so there is great need for molecular detection and alleviation mechanisms. To address this, we have genetically engineered a system to diagnose and treat Alzheimer’s disease. Diagnosis is based on the detection of two Alzheimer’s-specific biomarkers in the brain: extracellular beta-amyloid protein oligomers and the intracellular miRNA profile of afflicted neurons. Successful detection triggers a treatment module that reduces beta-amyloid levels, thereby preventing neuronal death and slowing the progression of Alzheimer’s symptoms. This research demonstrates an approach that could inform an eventual treatment, not only for Alzheimer’s disease, but for numerous other human afflictions."
+},
+{
+"Team":"Nagahama",
+"Year":2014,
+"Description":"One E.coli has one function theory",
+"Abstract":"The chemotaxis is a phenomenon to take action with the directionality for the concentration gradient of the existing specific chemical substance around a straight object. We make various systems by using chemoattractant. We keep one function in one E.coli. This theory means to make simple plasmid. The following is one example. We’d like to collect cadmium in water. Therefore we use two kinds of E.coli. One catches Cadmium. The other attracts all E.coli by using chemoattractant. Catches E.coli displays metallothionein a protein combines a heavy metal. Cadmium is a kind of heavy metal. The other synthesizes aspartic acid (Asp) one kind of chemoattractant. All E.coli gather in the E.coli synthesizes Asp. To use these E.coli, finally Cadmium will be caught."
+},
+{
+"Team":"Nankai",
+"Year":2014,
+"Description":"Super Petroleum Magician:an anaerobic rhamnolipid-producing engineered bacterial strain for microbial enhanced oil recovery",
+"Abstract":"Microbial enhanced oil recovery (MEOR) is a popular method that relies on microorganisms and their metabolic products to mobilize residual oil. Rhamnolipid, a widely-used biosurfactant produced by Pseudomonas aeruginosa under aerobic conditions, is helpful in reducing oil-water interfacial tension, which makes it easier to remove oil. However, because of the anaerobic environment in oil reservoirs, rhamnolipid has to be produced ex situ, and then injected into the oil reservoirs. Our project is to build a bacterial strain that is able to utilize oil as its carbon resource as well as producing rhamnolipid in anaerobic environment. We start with a Pseudomonas stutzeri strain that lives in the oil reservoirs, clone and make it express the rhamnosyltransferase operon genes rhlABRI from Pseudomonas aeruginosa so that it can produce and excrete rhamnolipid into the oil constantly. With all the strengths enhancing the oil recovery, we name our engineered bacterium “Super Petroleum Magician”."
+},
+{
+"Team":"Nanjing-China",
+"Year":2014,
+"Description":"BioLego: Toxin cleaner",
+"Abstract":"The contamination of ecosystems with a multitude of pollutants has been a problem since the industrial revolution. Toxins make up a high proportion of pollutants. Fugal toxins, Antibiotics, heavy mental and various natural toxins threaten environmental health and are not effectively removed by conventional environmental treatment. In order to avoid the disadvantages like high sensitivity; high cost and complicated operating process of traditional specific methods of treatment, we are hard to find a sensitive, selective, and convenient method. To do this, we aimed to create a BioLego of genetic parts for engineering complex E.coli. Our project has to design a modular system which makes it possible to quantitatively detect and degrade whatever kind of toxin, with its specific promoter and the coding sequence of its degrading enzyme. This BioLego will provide future iGEM generations and scientists worldwide with a greater ability to work with different kinds of toxins."
+},
+{
+"Team":"NCTU Formosa",
+"Year":2014,
+"Description":"Operation Debug",
+"Abstract":"Insect damage brings significant loss to modern agriculture and obstructs agricultural development. Most conventional treatments have harmful side effects, such as pollution and drug resistance. Currently, the use of pheromone traps is one of the cleanest methods to specifically attract and kill insects. Instead of carrying out the complex biosynthesis pathway of pheromones, we choose the simple act of expressing the DNA sequence of Pheromone Biosynthesis Activating Neuropeptide (PBAN). PBAN is similar to pheromone in its species-specificity. Once a specific PBAN comes in contact with and stimulates the target species, specific pheromones will be emitted to attract more of said species. In our project, we have successfully constructed and expressed in E. coli PBANs of nine different species and also built a capturing device. Hopefully this model can be widely used in the future when PBANs of more insects are found."
+},
+{
+"Team":"NEAU-Harbin",
+"Year":2014,
+"Description":"Gene Tracer, a Visual Gene Replacement System for Aspergillus Niger",
+"Abstract":"We aim to establish one visual operation system of continuous target gene replacement to transform target gene into the high expression site through homologous recombination in the Aspergillus Niger genome. In this construct, amilCP gene was driven by GlaA5 promoter, and followed by GlaA3 terminator; the HPH and cjBlue fusion gene was driven by pgpdA promoter, and followed by GlaA3 terminator. GlaA5 and GlaA3 can be used as homologous arm sequences that can mediate specific recombination. After homologous recombine between homologous arm sequences, we will get the transgenic Aspergillus Niger cells only express amilCP gene which can be easily detected by blue color. These transgenic Aspergillus Niger cells with blue color can be used as original strain for target gene transformation. Those colonies without blue color will be the real transformants in which amilCP gene is replaced with the target gene."
+},
+{
+"Team":"Nevada",
+"Year":2014,
+"Description":"BAIT Switch: Bioorthogonal Auxin Inducible Trigger for Protein Degradation",
+"Abstract":"In biological systems, changing from one state to another can depend on gene repression, induction of new genes, and degradation of previously used proteins. The ability to quickly and inducibly degrade a signal, repressor, or other protein would greatly improve the sensitivity and timing of biological switches. Auxin, a plant hormone, is involved in nearly every aspect of plant growth and development. In the presence of auxin, auxin receptors induce polyubiquitylation of a targeted protein, leading to degradation by the proteasome. This hormone based protein degradation has previously been used to create inducible protein degradation in yeast and mammalian cells. However, a parallel system – using jasmonic acid as the small molecule inducer – is also found in plants. Our goal is to use both the auxin and jasmonic acid responsive pathways to develop a quick, efficient, and bioorthogonal system to control protein stability in yeast. "
+},
+{
+"Team":"NEFU China",
+"Year":2014,
+"Description":"Nanocrystal E.coli Flocculation Union",
+"Abstract":"Heavy metals, especially zinc and cadmium, inevitably, have detrimental effects on the environment and our human race. To be more specific, water sources can be contaminated by heavy metals leaching from industrial waste; acid rain can exacerbate this process by releasing heavy metals trapped in soils. Considering the properties of heavy metals, unable to decay and thus a different kind of challenge for medication, we have constructed a heavy metal detection and recycle system. Briefly, our system is based on a special strain of E.coli containing smt-locus, CDS7 and an unfamiliar flocculation gene. The system can detect the existence of metal zinc and cadmium through visualized pigment gene driven by the smt-locus, recycle these heavy metal ions by forming nanocrystals resulted from CDS7 and flocculate the nanocrystals. Eventually, we can realize our double-win goal, safeguarding our environment by removing heavy metal ions and yielding a great amount of nanocrystals."
+},
+{
+"Team":"NJU-QIBEBT",
+"Year":2014,
+"Description":"E.coil",
+"Abstract":"Fatty acid(FFA) plays an essential role in many aspects of modern society, such as food industry, rubber industry, fuel, etc. Relied on animal grease or plant oil currently, the FFA production, however, is highly restricted by seasonal, regional factors and the expensive manufacturing cost. Therefore, we strive to transform E.coli into a biological factory that produces more FFAs of different length of carbon chain and saturation levels in both an efficient and a controlled manner. To achieve that, we will introduce FFA desaturase and various thioesterase, key enzymes for unsaturated FFA production and FFA synthesis respectively, and different operon structure into the engineering E.coli. Also, we design a fluorescence system composed of Transcriptional Regulatory Protein FadR to monitor the FFA producing status in E.coli. In this case, we can produce different FFAs by applying different signals to operons in E.coli and detect the real time production status by fluorescence report."
+},
+{
+"Team":"NRP-UEA-Norwich",
+"Year":2014,
+"Description":"Green Canary: Induction of chromoproteins to signal plant-pathogen interactions",
+"Abstract":"Food security is a prominent health challenge faced by the increasing global population, which is exacerbated by high loss of crop yields to pests and diseases. Applying synthetic biology approaches, we aim to produce proof of concept, sentinel plants that will diagnose the presence of two pathogens, Xanthomonas oryzae and Xanthomonas campestris. The plant sentinels will produce a chromoprotein output, observable by the human eye, within 48 hours of pathogen infection. The sentinels would allow growers to apply appropriate agrochemical application before the diseases progress to symptomatic pathogenesis in neighbouring crops. This approach will reduce crop losses whilst decreasing the necessity for continual use of agrochemicals. Furthermore, we are constructing a series of BioBricks that will allow Golden Gate assembly to assist cloning of transcriptional units within the iGEM standard. These important developments will aid future iGEM teams to work with plant chassis’ as well as utilise Golden Gate technology."
+},
+{
+"Team":"Northwestern",
+"Year":2014,
+"Description":"NU Models: Exploring Transcription and Translation Rates in Non-Model Organisms Using a Cell-Free System",
+"Abstract":"NU Models seeks to expand promoter and ribosome binding site characterization of E. Coli to other non-model organisms chosen for their promise in other fields of research. All processes take place in a cell-free system to provide a consistent characterization platform. This information is useful in synthetic biology applications for healthcare, the environment, and industry as it provides a basis for DNA design in organisms other than E. Coli that are more optimized for the needs of a given application. An example of a non-model organism that we are using with the cell-free system is Streptomyces, which has played an important role in antibiotic production. While we explore adaptation of the cell-free system to these non-model organisms, we also strive, through characterization of sets of promoters and RBS, to create a combination that would yield the maximum protein production."
+},
+{
+"Team":"NTNU Trondheim",
+"Year":2014,
+"Description":"SynECO2 - Light driven carbon capture",
+"Abstract":"The changes observed in the global climate within the last hundred years have been attributed to rising atmospheric levels of carbon dioxide (CO2). This heavy increase in atmospheric CO2 is thought to be caused by the heavy industrialisation of our civilisation with the use of fossil fuels. With the potential impact climate change could have for many ecosystems globally, it becomes apparent we need to slow-down, if not prevent these changes in order to preserve our current habitat. One strategy for reducing the CO2 concentrations in the atmosphere is biological carbon fixation. The project undertaken will look at establishing the lactate inducible expression system into Synechocystis sp. PCC 6803. Once established, glucose oxidase (GOx) will be incorporated into this expression system. It is proposed that Glucose oxidase will prevent respiration of the organism, thereby increasing its carbon fixation capacity."
+},
+{
+"Team":"NTU Taida",
+"Year":2014,
+"Description":"Skin-guardian",
+"Abstract":"The oil oozes and gives the skin a greasy shine, and that’s one of the most fearsome nightmare of human. We expect ourselves to solve this problem by producing skin-care ingredients with fatty acid metabolism related gene circuits in our gene modified e-coil, skin-guardian. In our project, we have three kinds of skin-care ingredients to skin whitening, keratin decomposition and fragrance producing respectively. When skin-guardians uptake excess oil and sebum through fadl, it will synthesis acetyl coenzyme a, which will change the structure of repressor, fadr losing its affinity to promoter. And our skin-guardian can started to translate genes, make us looks fair and tender. Living through numerous theoretically and practical examinations, our skin- guardians proofed itself to be a great expectations in aesthetic medicine."
+},
+{
+"Team":"NUDT CHINA",
+"Year":2014,
+"Description":"Programming bacteria to solve the shortest path problem in a directed graph",
+"Abstract":"The Single Pair Shortest Path Problem (SPP) is one of the basic problems with many applications. Many computational methods, such as Dijkstra algorithm etc., can solve it in a tolerable computational complexity. However, as the technology of the traditional silicon computers is gradually meeting its physical limits, new methods of the high-volume computing has been looked for for years. As developing rapidly, synthetic biology makes bacterial computing possible and great potential. Here, we designed a series of genetic circuits in Escherichia coli to solve the SPP in a directed graph. The nodes and arrows are programed as well-assigned promoters and transcription factors (TFs) respectively. The paths in the graph are described by the transcriptional regulatory cascades. The promoter of destination node in SPP is followed by a green fluorescent protein (GFP) as a reporter. According theoretical analysis, we can find the the shortest path with linear computational complexity."
+},
+{
+"Team":"NU Kazakhstan",
+"Year":2014,
+"Description":"E.Coli derived camelid p53 antibodies: a way to detect cancer in saliva",
+"Abstract":"Oral squamous cell carcinoma (OSCC) is a malignant tumor with 640,000 new cases annually worldwide. Saliva testing is non-invasive procedure that allows detecting OSCC biomarkers. Elevated level of p53 protein was identified in OSCC patients at different stages of the disease. Camelid antibodies containing only variable regions, nanobodies (VHH) and single-chain variable regions (scFv) with VH and VL, are becoming popular in research and diagnostics. It was identified that VL region showed higher affinity for p53 than VHH, and dimerization of VL regions increases their affinity up to ten folds. Camelid antibodies can be conjugated to other proteins without loss of function. They can be expressed and secreted in such common model organism as E. coli, reducing the cost of antibody production. Therefore, the aim of this project is to design biosensor to detect p53 in saliva samples for OSCC diagnosis using nanobodies expressed in bacteria."
+},
+{
+"Team":"NYMU-Taipei",
+"Year":2014,
+"Description":"HOPE (Human Oral Protection for Everyone)",
+"Abstract":"Many methods have been used to improve oral health. However, there is no silver bullet to solve oral microbial problems for people living with disabilities and long-term illness. Therefore, 2014 NYMU-Taipei has decided to provide a HOPE, Human Oral Protection for Everyone. HOPE, is an auto-adjustable bio-drug system with a concept of 4Cs, which are Control, Communication, Cure and Caution, taking cares the stages of prevention, cure, and notice, giving users a care-free oral cavity. 1. Control: control oral pathogens at a moderate level, which gives a lower harm without disturbing oral ecology. 2. Communication: specific targeting phage will send SOS signals for activating killing functions of designer probiotics. 3. Cure: probiotics are applied to cure cavities by biofilm degrading and acid decreasing. 4. Caution: A fruit smell is engineered in a native strain, which grows naturally according to dental decay. It is notion for going to dental care."
+},
+{
+"Team":"OU Norman",
+"Year":2014,
+"Description":"How to train your Clostridia",
+"Abstract":"Due to environmental concerns and fuel prices, much research has been invested in alternative sources of fuels. Development of biofuels, in particular, is beneficial in the sense that it provides a renewable source of energy with a wide range of energy densities. Clostridium acetobutylicum has great potential for producing biofuels due to its native ABE (acetone, butanol, ethanol) fermentation pathways and its ability to metabolize a variety of carbon substrates. In addition to C. acetobutylicum’s native pathways, the introduction of non-native genes makes it possible to expand the types of alcohols produced. The goal of this research endeavor was to develop an iGEM compliant Clostridial shuttle vector to introduce genes for the production of branched and longer chain alcohols within Clostridial species. We are in the process of testing our shuttle vector and plan to compare alcohol production efficiency between anaerobes and aerobes."
+},
+{
+"Team":"Oxford",
+"Year":2014,
+"Description":"DCMation: decimating DCM pollution.",
+"Abstract":"Chlorinated solvents are indispensable to industry, research and household applications. Their accumulation in water supplies and carcinogenic properties present a major environmental and health hazard. OxiGEM are tackling the issue by developing a bioremediation/detection kit to dispose of the common chlorinated solvent dichloromethane (DCM). Our system design, inspired by the DCM-degradation pathway of M. extorquens DM4, is initiated and refined by the dialogue between modeling simulations and experimental data. Incorporation of novel diffusion-limiting biopolymeric beads to encapsulate engineered bacteria ensures safe and efficient DCM degradation. We are constructing a synthetic fluorescent biosensor through GFP fusion to the dcmA promoter, regulated by the DCM-binding protein, DcmR, and maximising the sensitivity and catalytic efficiency of the system through directed evolution. Our DCM clean-up solution, branded ‘DCMation’, will be user-friendly in a wide range of workplaces and extendable to the disposal of many other harmful substrates."
+},
+{
+"Team":"OUC-China",
+"Year":2014,
+"Description":"The Adventure of Plasmid",
+"Abstract":"Generally, researchers transfer plasmids from prokaryote to eukaryote by non-autonomous methods. While we manage to make plasmid transfer by autonomous and convenient methods. Hence this year, OUC-China iGEM devotes to design a novel model of plasmid transfer. Because the plasmid can’t transfer into natural bacteria easily in vivo. We transport the plasmid with double plasmids system into the organism, and then the constructed plasmid that has lysis device can transfer to the dominant colony in organism by conjugation. Afterwards, the dominant colony with constructed plasmid can lysis and release the constructed plasmid and a fusion protein composed of cationic TAT peptide and histone H4 that we has designed. The protein complexes will carry the constructed plasmid into eukaryote to make molecular operation. The project is to construct a novel model method of eukaryotic transfection for molecular biology research at individual level such as DNA vaccine and molecular marker."
+},
+{
+"Team":"Paris Bettencourt",
+"Year":2014,
+"Description":"The smell of us",
+"Abstract":"Body odors are complex phenomena observed among mammalian species. Corynebacterium striatum and Bacillus subtilis are among the main contributors to body odors. One of the objectives of our project is identifying and isolating natural mutants that have non-functional odor-producing enzymes using CRISPRs. We’re also engineering bacteria to degrade smelly molecules: TMA (trimethylamine) and 2-nonenal. The old people smell is mainly due to 2-nonenal. To degrade it, we want to perform directed evolution on skin bacteria. TMA has a fish odor and it appears in people suffering from trimethylaminuria. We will clone the enzyme trimethylamine monooxygenase, which degrades TMA, in E.coli and skin bacteria. Parallelly, we intend to develop a set of primordial odors by cloning enzymes known to catalyze reactions yielding volatile compounds. We’re also focusing on scientific communication, for that, we are developing an online course developed on the Education Genius platform about iGEM high school."
+},
+{
+"Team":"Paris Saclay",
+"Year":2014,
+"Description":"This is not a lemon!",
+"Abstract":"Synthetic Biology has the power of changing paradigms of society such as our conception of what living beings are. If we deprive bacteria from their “unnecessary” functions and have them produce what we need, do these bacteria still possess the status of living organisms or have they become machines? To raise this question, we adopted an artistic approach, as Bio-Art is one of the best way to spark debate with citizens. We create a concept organism that would reflect these interrogations. We modify Escherichia coli to produce the scent and simulate the ripening process of a lemon. A mixture of bacteria and growth medium will be molded: it will smell, ripe and look like a lemon, but “ceci n’est pas un citron” - this is not a lemon… or is it? With this we invite everyone to think about the upcoming opportunities and the ethical limits of designing living beings."
+},
+{
+"Team":"Penn",
+"Year":2014,
+"Description":"Cadmium recovery by a recombinant Magnetospirillum magneticum AMB-1",
+"Abstract":"Exposure to cadmium, a heavy metal commonly used in industrial processes, causes serious health problems including kidney disease, lung damage, bone fragility, cancer, infertility, and death. There is significant demand for the effective bioremediation of cadmium in developing countries and in industrial regions. Current methods are expensive and often produce undesired byproducts. We engineered a strain of magnetotactic bacteria known as Magnetospirillum magneticum AMB-1 for biosorption of cadmium. AMB-1 is a strain of magnetotactic bacteria that aligns to magnetic fields with magnetite-accumulating organelles. This strain has been identified as a suitable chassis as it can be isolated with magnetic forces. A metal transporter gene native to other magnetotactic strains (mntH) and a S-adenosyl-methionine-dependent methyltransferase (smtA) derived from E. coli were incorporated into a genetic circuit designed to maximize biosorption and cadmium tolerance. AMB-1 carrying this design on a shuttle vector plasmid were tested for bioremediation efficiency."
+},
+{
+"Team":"Peking",
+"Year":2014,
+"Description":"Ranger amongst Enemies",
+"Abstract":"Widespread water bloom leads to extensive damage in ecosystems. Compared to physical or chemical methods, biological treatment for water bloom is less expensive and more environmentally friendly. Hence Peking iGEM is dedicated to constructing engineered microorganisms for the elimination of algae and recovery of ecosystems. A specific antimicrobial peptide is secreted to disrupt the outer membrane of algae. In addition, we equip our transgenic cells with features that allow for buoyancy and attachment, making our project more efficient. During this process, an enzyme is also secreted to degrade a deleterious product of algae. After eradicating the algae, our engineered bacteria will commit suicide, and the ecosystem is finally restored. This project is an innovative treatment for water bloom, and has potential applications in the field of ecosystem remediation."
+},
+{
+"Team":"Penn State",
+"Year":2014,
+"Description":"Next-Generation Approaches to Overcome the Challenges of Metabolic Pathway Engineering",
+"Abstract":"Engineering metabolic pathways requires answering several questions and often performing many experiments. We sought to answer such “combinatorial questions” using new biophysical models and experimental approaches. First, we employed the CRISPR/Cas9 system to identify the missing enzymes of a metabolic pathway that functions in one organism, but not in another. We demonstrate our approach on a 5-enzyme catabolic pathway that functions in P. putida, but not in E. coli. Once a multi-enzyme pathway functions in a preferred host, the DNA sequence of the system must then be optimized to achieve a desired metabolic activity. We took a forward engineering approach to systematically investigate the differences in translation rate capacity when using either “frequent”, “fast”, “rare”, or “slow” synonymous codons during codon optimization of protein coding sequences. Our research will enable metabolic engineers to overcome two of the most commonly encountered combinatorial questions during metabolic pathway engineering."
+},
+{
+"Team":"Pitt",
+"Year":2014,
+"Description":"Building a Toolkit to Engineer the Skin Bacterium, Propionibacterium Acnes",
+"Abstract":"The goals of the Pitt iGEM team are to: 1. Engineer a plasmid that will replicate in P. acnes. This plasmid will also be compatible with the synthetic biology standard RFC10, allowing for the simple addition of genes. 2. Optimize a protocol to transform P. acnes with our engineered plasmid using statistical design of experiments. 3. Transfer the following beneficent genes to P. acnes for function as a skin probiotic: 3.1 Melanin - for skin pigmentation and UV protection. 3.2 Aldehyde Dehydrogenase - for destruction of sebum (oil) on skin 3.3 Cathelicidin - for defense against bacterial infection."
+},
+{
+"Team":"PoznanSoft",
+"Year":2014,
+"Description":"MUFASA: Multiple fragments assembler for scarless cloning of big genetic constructs.",
+"Abstract":"Overlap-based cloning techniques like Gibson Assembly and Circular Polimerase Extension Cloning (CPEC) have been recently becoming more and more popular. While available software allows rapid overlap design for constructs of conventional size, details of its functioning are not always fully transparent. MUFASA aims not only at facilitating the scarless cloning from the oligonucleotide design to putting the tubes into the thermocycler, but also at designing the fragments themselves in parallel with the overlaps for synthesis of big constructs de novo. Use of multiple overlaps pose a risk of non-specific hybridization and overlap “shadowing”. Such “shadowy places” may be eliminated by thermodynamic sequence optimization of both CPEC primers and fragments of the desired construct."
+},
+{
+"Team":"PoznanBioInf",
+"Year":2014,
+"Description":"REColi: Signal amplification and formattable bacterial memory by DNA edition.",
+"Abstract":"We have designed a synthetic digital device inspired by electronic circuits called multiplexers. Its 3-bit memory allows saving and processing binary inputs in E. coli. Induced expression of serine recombinases, capable of specific DNA editing, enables construction of biological analogues of transistors - transcriptors - and their use as elementary memory units called SR-latches. The fourth, strobe signal resets the system to its original state. We have shown that the system could efficiently store data about previous contact with inducing sugars across hundreds of generations. This memory unit offers high sensitivity in inducer detection and signal amplification, allowing cheap induction or further development and use as a trace contaminants sensor. Eight possible output combinations, reported as RGB fluorescent proteins, may also turn out to be useful for complex coexpression research."
+},
+{
+"Team":"Purdue",
+"Year":2014,
+"Description":"Minecrobe: Bacillus subtilis Production of Corn Phytosiderophores to Combat Malnutrition",
+"Abstract":"More than 870 million people are malnourished according to the United Nations World Food Program, and the World Health Organization states that iron deficiency is one of the most common and widespread nutritional disorders in the world. A solution is presented by utilizing synthetic biology to engineer Bacillus subtilis to increase plants’ ability to uptake iron, through production of plant phytosiderophores. Phytosiderophores are small, high-affinity iron chelating molecules that many microorganisms and plants use to increase bioavailable iron by reducing Fe3+ to Fe2+. Our genetically engineered system combines five corn genes to produce these phytosiderophores: SAMS, NAS1, NAATI, DMAS, and TOM1. We are using corn and rice to confirm that plants grown with our engineered bacteria will have higher iron content than plants grown with wild-type Bacillus or with no Bacillus at all. Mass spectrometry, chlorophyll readings, and height measurements were used to determine the effectiveness of our engineered system."
+},
+{
+"Team":"Queens Canada",
+"Year":2014,
+"Description":"Inteins- Designed by Nature, Accessible by Design",
+"Abstract":"Found across all domains of life, inteins are protein elements capable of autocatalytic splicing. This phenomenon, termed protein splicing, allows inteins to be a point of control in forming mature and functional protein products. Current genetic circuits are limited by transcriptional lag, rendering them limited in applications which require fidelity and responsiveness. Inteins represent an innovative solution to improving the sensitivity of biosensors and synthetic circuits circumventing this lag and controlling the output of the circuit at the protein level. Here, we have created an intein toolkit, designed to introduce and facilitate the use of inteins in future iGEM projects. We have engineered several inducible intein switches capable of being activated by common environmental triggers as well as small molecules. To showcase the utility of inteins, we have also developed an intein based system to tackle mitochondria disease by allotropically expressing and transporting mitochondria proteins using inteins."
+},
+{
+"Team":"RHIT",
+"Year":2014,
+"Description":"Synthetic Unity",
+"Abstract":"Our project explores synthetic obligate mutualism as a means to produce novel, multi-species chassis as foundations for innovative synthetic biological applications. These applications could exploit unique biochemical potentials emerging within chimeric systems. Here we explore the pairing of Saccharomyces cerevisiae and Escherichia coli by constructing genetic circuits for reciprocal induction of essential histidine biosynthetic genes. Since one species relies on the other for induction of their own essential gene, mutualism is obligatory. Another key component of our efforts addresses the need for effective interactive models to facilitate teaching and understanding of synthetic biology concepts. Victor the Vector is an electromechanical device, which combines circuits and software to not only model components of our project; but to facilitate understanding of gene regulation and the synthesis of genetic circuits. In toto, Team RHIT strives to stimulate innovation and education in synthetic biology."
+},
+{
+"Team":"Reading",
+"Year":2014,
+"Description":"Cyanobacterial photovoltaic cell: electrons from unexpected places",
+"Abstract":"Photovoltaics are one of the main sources of renewable energy and are likely to become more widely used in the future, but their production is expensive and involves toxic materials. Biological photovoltaics (BPVs) have the potential to provide a cheaper and more sustainable alternative, especially where energy demand is lower. They could power the social, welfare and economic growth for the 1.2 billion people without access to electricity. BPVs take advantage of photosynthetic organisms by harnessing the electrons they produce from water and sunlight. We aim to increase their output by redirecting electron flow in the cyanobacteria Synechocystis sp. PCC 6803. To achieve this we have targeted areas in the photosynthetic electron transport chain to increase electrons, and pilus production to improve transfer to the anode."
+},
+{
+"Team":"Rutgers",
+"Year":2014,
+"Description":"Enzymatic de novo DNA Synthesis",
+"Abstract":"The synthesis of nucleic acids with custom sequences is a very important tool in the research of biological systems. The prevailing strategy for DNA synthesis is the phosphoramidite strategy, which involves anhydrous solvents and acidic environments that are slightly harmful to DNA, causing small amounts of side reactions that limit overall efficiency and yield. In theory, using enzymes instead would eliminate all deleterious side reactions, allowing for extremely high levels of efficiency that would lead to very inexpensive gene-length DNA synthesis. A template-independent polymerase called Terminal Transferase was tested as a catalyst for the Coupling reaction, and several different Esterase enzymes were tested as catalysts for the Deblocking reaction."
+},
+{
+"Team":"Saarland",
+"Year":2014,
+"Description":"Project Rufus or the Force of the Naked Mole Rat",
+"Abstract":"Cancer is not only one of the most common diagnoses, but also the leading cause of death worldwide. There are only limited therapeutic possibilities and these are mostly associated with adverse effects. A special form of hyaluronic acid has the potential to become an innovative therapeutic drug for the treatment of cancer. Originally discovered in connective tissues of Heterocephalus glaber this high-molecular-mass hyaluronic acid (HMM-HA) is supposed to mediate the cancer resistance in this species. Our aim is to employ a simple soil bacterium as an expression system for the first ever biotechnological production of this HMM-HA. After purification we want to test and further characterise its inhibitory effect on carcinogenesis in selected human cancer cell lines. We are confident that the anti carcinogenic properties and high biocompatibility of our synthesized HMM-HA will herald a new age of fighting cancer."
+},
+{
+"Team":"SCU-China",
+"Year":2014,
+"Description":"Imperial Edict:Simulating Signal Analysis & Transfer Using E.coli",
+"Abstract":"Our project is focusing on using the simple prokaryotes to imitate the nerve system which exists in the advanced animals widely. As we all known, the nerve system of advanced animals like human consists of 3 major parts: the receptive neurons, the central neurons, and the effector cells. Correspondingly, we separate bacteria into 3 different communities to execute different functions and we name these 3 communities as Receptor, Transmitter, and Effector. In details, we replace the neurotransmitter by AHL family and in the meanwhile, we construct the multiple promoter to simulate the procedure of signal receiving and processing. In addition, for the sake of achieving the signal transmitting and analyzing, we isolate a new cell quorum sensing system—the PPYs signal pathway from photorhabdus luminescence. The mechanism of this PPYs signal pathway is similar to the AHLs pathway."
+},
+{
+"Team":"SCAU-China",
+"Year":2014,
+"Description":"High Efficiency MFC-Based Seawater Desalination Device",
+"Abstract":"In view of rapid depletion of traditional energy resources and increasing demand of desalination of seawater for fresh water, we aimed to enhance the electrogenic capacity of microbial fuel cells (MFC) by genetically modified bacteria and optimize the traditional microbial desalination cells (MDC) device. We knocked out the arcA gene, over-expressed the nadE gene and incorporated the porin OprF in cell membrane in E. coli. These modifications released the inhibition of metabolic enzymes in anaerobic condition of ArcA protein, also boosted up intracellular NAD+(H) level for higher electron transferring rate and provided membrane channels for electron exchange, by which the electrogenic capacity of the MFC was collectively enhanced resulting in a high efficient seawater desalination in MDC system."
+},
+{
+"Team":"SCUT",
+"Year":2014,
+"Description":"The Forgotten Corner——Cellular Compartment",
+"Abstract":"This year, we focus on “cellular compartment”, aiming to construct a much more effective metabolic pathway in the full use of the advantages of different, membrane-bounded organelles. Concretely, we’ve built up a pathway to produce n-butanol in yeast. Throughout the pathway, all enzymes are transported into the mitochondria with the employment of leading peptide. We hope to bring the output of n-butanol up to a brand new level by utilizing higher concentration of ATP and the powerful coenzyme regeneration system in mitochondria. Moreover, we have assembled a CO2-fixing device with enzymes PRK, Rubisco and CA which are combined by scaffold protein. In order to take advantages of characteristics of subcellular structure, this device was anchored in outer membrane of mitochondria. Finally, we aim at raising the output of n-butanol by fixing CO2 with Rubisco. Meanwhile, we’ve built up and tested out leading peptides of other organelles for future research."
+},
+{
+"Team":"SCUT-China",
+"Year":2014,
+"Description":"Programmed polyketide synthesis",
+"Abstract":"Polyketides are a class of secondary metabolites produced by almost all living organisms. These are structurally complex organic compounds that are often highly active biologically. Many pharmaceuticals are derived from or inspired by polyketides. For the heterologous expression of polyketide synthases(PKSs), the main method of the technology is transferring full gene cluster into heterologous host strains. However, such method can’t synthetize various polyketides by the same polyketide synthase domains. This year, we are dedicated to using PKS domains as a synthetic unit to diminish the size of the target gene fragments. Meanwhile, the host strain E. coli should be genetically modified in order to enable the synthesis of the corresponding substrate. In this way, PKS domains can be assembled more quickly, enabling the programmed polyketide synthesis. In addition, we can design synthesis pathway of polyketide independently. This system can select the corresponding synthesis polyketide synthase domains to synthetize polyketide programmedly."
+},
+{
+"Team":"SF Bay Area DIYbio",
+"Year":2014,
+"Description":"Real Vegan Cheese",
+"Abstract":"Environmentally conscious individuals, vegans, and vegetarians worldwide crave a suitable alternative to cheese that is cruelty-free and environmentally friendly. We are attempting to create the first real vegan cheese by engineering normal baker’s yeast (S. cerevisiae) to express cheese proteins (caseins), purifying the proteins, creating a milk-substitute by blending in vegan replacements for lactose and milk fat, and finally turning the resulting milk-substitute into semi-hard cheese like gouda using the normal cheese-making process. We will express the four casein proteins, as well as the Fam20C Golgi kinase that phosphorylates the caseins, with an alpha factor tag that targets them for secretion. The Real Vegan Cheese project (aka iGEM team SF_Bay_Area_DIYbio) is a community team of more than two dozen individuals from all walks of life, sponsored by DIYbio labs Counter Culture Labs from Oakland and BioCurious from Sunnyvale. "
+},
+{
+"Team":"SDU-Denmark",
+"Year":2014,
+"Description":"Edible coli - The untapped food resource of the century ",
+"Abstract":"Edible coli is a nutrition source of high quality emerging from a yet untapped food resource: Escherichia coli (E.coli). Through genetical modification, an odorless E. coli strain will be able to overproduce a self-designed wonder protein, containing the exact ratio of essential amino acids needed in the daily diet. Furthermore, the Edible coli will be able to produce essential fatty acids, Ω3 and Ω6. Neither of these products can be synthesized by the human body. This amazing nutrition-combo will be obtained from the degradation of otherwise non-degradable material for humans, such as cellulose. Edible coli is thus a bacteria containing some of the optimal quantity of nutrition a person needs, and will at the same time be tasty – with a touch of lemon."
+},
+{
+"Team":"Sheffield",
+"Year":2014,
+"Description":"The Fatberglar: A small scale, semi-continuous bioreactor for the controlled release of FOG degrading enzymes",
+"Abstract":"Fats, oils and greases (FOGs) enter the national sewage system and accumulate, leading to blocked pipes, nicknamed “fatbergs”. There are currently over 200,000 major UK sewage blockages a year, of which 75% are caused by FOGs; tackling these blockages costs water companies millions of pounds every month. The biological project work focused on development of constructs that produce lipase and keratinase enzymes to degrade FOGs and hair. These constructs are designed to sit within a small, under-sink bioreactor that will produce and feed them into the waste system as the sink is drained. To shape the approach, there has been significant interaction with industry experts and the public to gauge where the responsibility lies for the maintenance of the damaged drains; awareness of synthetic biology has been raised alongside this. A novel method of characterising the t component of the iGEM competition is also presented here. "
+},
+{
+"Team":"SJTU-BioX-Shanghai",
+"Year":2014,
+"Description":"MembRing",
+"Abstract":"This year, we bring MembRing – an annular protein multimerization system in cell membrane. This system will help us achieve the goal of selective polymerization of enzymes. Polymerized enzymes, different from normal scattered condition, has much more opportunities to contact with the substrates. Therefore, our project aims to increase as well as control the efficiency of complex reactions. The basic function, polymerization, is carried out by a circular DNA and DNA-binding protein to polymerize enzymes. First, a fluorescent protein, a transmembrane domain, an enzyme, and a DNA binding protein are connected in order, forming a complex in which the fluorescent protein locates outside the cell membrane while the enzyme and DNA binding protein are in cytoplasm. Then to integrate specific matching DNA sequences into an exogenous plasmid and co-transform this connecter with expression vectors into E.Coli to associate enzymes."
+},
+{
+"Team":"SJTU-Software",
+"Year":2014,
+"Description":"Evaluation, Visualization, Simplification, Standardization of Biobrick Information and Biosystem Design ",
+"Abstract":"Confusing biobrick database and different ways of interpreting the bio-system remain to be two main problems in synthetic biology. To help wet-lab users get neat information and evaluation of specific biobricks quickly and to display their bio-system easily, we create “Easy BBK”. Users can input keywords of the biobrick they are interested in and select special requirements of certain properties that are listed in the software, biobricks related will be listed, sorted by a score given to each biobrick, which takes into consideration the current status, user comments and reviews, times of citation in a publication and etc. Additionally, Users could draw their bio-system easily with the standardized biobrick icons, and they can also look into the detailed information about the biobricks in the bio-system. Finally, before self-created biobricks are uploaded to the official database, users could first assess their biobricks in our software according to our assessment model."
+},
+{
+"Team":"StanfordBrownSpelman",
+"Year":2014,
+"Description":"Towards a Biosynthetic Unmanned Aerial Vehicle",
+"Abstract":"There are growing applications for unmanned aerial vehicles (UAVs) in both space exploration and terrestrial activities, such as remote environmental monitoring and payload delivery. However, these devices are complex, costly, and made of non-eco-friendly materials, preventing their widespread use in scientific and humanitarian missions. We are pioneering the development of the first biologically-produced UAV, which will present numerous advantages over the current manufacturing paradigm. First, a foundational architecture built by cells allows for construction in almost any location and responsible disposal through biodegradation. To this end, we are synthesizing a novel cellulose acetate bioplastic, characterizing natural waterproofing proteins, and programming timed biodegradation. Second, we are leveraging synthetic biology to move costly analytic functions, which require bulky electrical components, into a cell layer with biosensing capabilities. In thinking about synthetic biology in the environment, we developed the Amberless Toolkit as a standard for preventing expression of synthetic constructs in undesired organisms."
+},
+{
+"Team":"Stony Brook",
+"Year":2014,
+"Description":"Apis-Biotics: Using a Bee Venom Compound as an Alternative to Antibiotics",
+"Abstract":"Pathogenic bacteria are becoming increasingly antibiotic-resistant, even to last-resort antibiotics. In addition, infections caused by some harmful strains of bacteria, such as Pseudomonas aeruginosa, cannot easily be treated with antibiotics or other common forms of treatment. We propose a strategy against this sort of resistance which uses the bee venom compound melittin to target pathogenic bacteria. Our intention is to engineer cells which can both produce our compound and recognize the communication signals of Pseudomonas aeruginosa, allowing our system to maintain some target specificity. Two plasmids, one which controls the production of melittin and the other which acts as the cell-signal receiver, will be inserted in E. coli cells. When melittin is released, it can then insert into the outer membranes of a bacterial cell, creating pores which then cause cell lysis."
+},
+{
+"Team":"Sumbawagen",
+"Year":2014,
+"Description":"ECONEY",
+"Abstract":"ECONEY is a mobile device from an engineered E coli that capable to measure different level of glucose in honey by calibrating the color of E. coli medium. Our circuit utilizes catabolite repression mechanism of E coli to measure the concentration of glucose in honey. We construct plasmid Bba_J04450 by inserting either Adenylate cyclase or IIA Glc which may affect the sensitivity of catabolite repression. Creation of novel circuit which consists of constitutive promoter followed by either Adenylate Cyclase or IIAGlc genes, which placed downward lac-mRFP circuit, may affect the sensitivity of catabolite repression. We expect an engineered E coli shows red color expression in different range of glucose concentration. By changing mRFP gene with amilCP, a blue fluorescent protein, we may obtain E. coli expressing either red or blue color when different honey added to the medium due to different glucose concentration."
+},
+{
+"Team":"SUSTC-Shenzhen",
+"Year":2014,
+"Description":"Application of CRISPR/Cas and A-B Toxin System in Resisting Retrovirus",
+"Abstract":"In this project, we want to establish a more effective HIV-curing system with less side-effects by integrating CRISPR/Cas system into human hematopoietic stem cells, which aims to protect the helper T cells from virus infection. The gRNA is designed to target the relative conserved regions in HIV viral genome and inactivate its biological activity. Since viral vectors seem to be of limited use in gene therapy strategies (e.g., potential pathogenicity), there is still a need for a simple, efficient nucleic acid transfer system which allows the target-cell-specific introduction of nucleic acids. By using non-viral DNA delivery system like A-B-toxin-GAL4 fusion protein, we can deliver plasmids encoding gRNA into the helper T cells and readily attack multiple HIV genome sites simultaneously and update the targets along with our knowledge of HIV."
+},
+{
+"Team":"SYSU-China",
+"Year":2014,
+"Description":"Integrated Evolution Machine",
+"Abstract":"Current methods of high-affinity protein selection are time-consuming and laborious, which hinders the application process. This year, by constructing an integrated protein evolution machine, we made it automatic and efficient. A broad diversification was accomplished by a DNA mutagenesis module in the host bacteria, which enabled prototype protein sequence, carried by the budding-deficient M13 bacteriophage, to generate a library of candidate proteins. Subsequently, bacterial-two-hybrid system was used to give selection pressure on these candidates. Only the favorable candidate proteins can activate compensating gene transcription and rescue phage budding, thus enriching favorable protein sequence in the phage population. Moreover, an RNA thermometer, on the compensating gene mRNA, was applied in the phage amplification process to make it more controllable. Finally, by integrating all the diversification, selection and amplification process, our integrated directed evolution machine can make it an automatic and controllable process for high-affinity protein selection."
+},
+{
+"Team":"SYSU-Software",
+"Year":2014,
+"Description":"FLAME -- Framework-based Layout And Metacircuit design Engine",
+"Abstract":"Based on principles of design frameworks, this software provides you with smarter, more automatic designs. With standardized biobricks and databases, the software automatically joins parts and modules and consequently a system come into being. That is, after you define the inputs, outputs and logic between them, our software offers you with different solutions (that is, different mechanisms for the same effect), the performance of each can be visible via a rader map. The built-in databases are abstracted from papers of considerable values of reference. It is far from finishing a design when a system comes out. Our software can mathematically simulate three major characteristics that describe the behaviour of the system: static performance, dynamic performance and expression efficiency, which might help you determine the performance of your designed system." 
+},
+{
+"Team":"SZU-China",
+"Year":2014,
+"Description":"Super Dream Factory of Cellulase",
+"Abstract":"To enhance the effects of decontamination in various fields, we use an alkaline cellulase as detergent additive. The alkaline cellulase gene was introduced into the Escherichia coli and the target enzyme can be highly produced with the help of Kil, which is one of the core elements of our project. What’s more, MdfA, a proton pump across the cell membrane, was added to transport the proton into the cytoplasma, and release Na+/K+ at the same time, resulting in cell survival in alkaline industry wastewaters as high as pH 10. Another highlight of our project is that we also added a ccdAB suicide system to our e-machine, by this we could remove the biological machine whenever we need for biological safety"
+},
+{
+"Team":"Tec-Monterrey",
+"Year":2014,
+"Description":"A novel cancer therapy delivered by bacteriophages in E. coli that triggers apoptosis",
+"Abstract":"By harnessing the inherent ability of facultative anaerobic bacteria to colonize and grow in tumoral environments, this project aims to develop a bacterial cancer therapy. A genetically modified E. coli will have knockouts in the lpp and msbB genes, which encode for the Braun’s lipoprotein and for the myristic acid moiety transporter of the lipopolysaccharide respectively. These genes are known to trigger an immune response in the human body; by deleting them, the impact of a bacterial intravenous administration will be reduced. Furthermore, these bacteria will produce M13-modified bacteriophages under the control of a quorum sensing system. They will be able to bind to cancerous cells, internalize and transfect them with two different genes: apoptin, responsible for an apoptotic protein specific for cancerous cells and a survivin siRNA. The latter will inhibit the uncontrollable growth characteristic of cancer cells, making them more vulnerable to apoptosis."
+},
+{
+"Team":"TCU Taiwan",
+"Year":2014,
+"Description":"Trogene Horse",
+"Abstract":"This year, we are trying to develop a CRISPR system combined with phage transduction to solve bacteria’s resistance to antibiotics. The type II CRISPR system is a powerful mechanism in gene engineering. This system has been proved to have more efficiency than other mechanisms such as zinc finger or TALEN. However CRISPR can only function within one cell, so we use M13 phage as vector to send our CRISPR into bacteria cells to cure their resistance for M13 is a lysogenic phage. In order to regulate our phage transduction, we use phagemid pBluescript and M13KO7 helper phage. The pBluescript contains our designed CRISPR system, it will produce CRISPR-transferd M13 phage only when a helper phage infect bacterium which have pBluescript. Then the engineered M13 phage will infect other bacteria and induce transduction of CRISPR system. Once we start the CRISPR, it will recognize and knock down the antibiotic resistance gene."
+},
+{
+"Team":"Safie",
+"Year":2014,
+"Description":"Technion-Israel",
+"Abstract":"Our team is building a proof-of-concept computational network using E. coli cells for the detection of trace amounts of harmful substances, such as allergens in food. Each cell is an independent computational module programmed to execute instructions based on common input. They comprise bypassed toggle switches - mimicking transistors (the basis of any computational system), an interchangeable promoter serves as an input port, and a histidine kinase two-component signaling system fused to a sensor in the periplasmic domain will serve as a converter for other input signals. The independent modules communicate using quorum sensing to produce a unified output signal. We are chemically synthesizing a photo-switching molecule connecting the cells together, creating an artificial biofilm. The result is a network made of independent computational elements that upon detection of a substance, co-operate to provide the user with an output visible to the naked eye."
+},
+{
+"Team":"The Tech Museum",
+"Year":2014,
+"Description":"e.Mosaic",
+"Abstract":"Our goal is to create an activity where Tech Museum visitors with no biology background can become part of our team and can engage in the hands-on experience of engineering a bacteria. In our project, they are guided through the transformation of a plasmid into e.coli and how we randomized the amount each of the three color reporters are expressed. When the transformed bacteria grow, each colony appears as a different color, essentially creating bacterial “pixels” representing a particular combination of the protein levels of each reporter. Visitors take these to a scanning station that uses computer-vision software to quantify the color and intensity of each colony. This is the first time a museum has entered this competition and our team is prototyping ways we as an institution can offer novel activities for our community to both learn and develop the skills of future innovators."
+},
+{
+"Team":"Tianjin",
+"Year":2014,
+"Description":"Transfibre",
+"Abstract":"Biosensors are becoming more and more indispensable tools in life science, medicine, chemistry and biotechnology. Yet in the bio-sensing procedure, the limitations of signal output methods restrict the usage and practicality of biosensors. Wildly used reporters such as chromophore and fluorescent protein which requires laboratorial equipments to measure often result in the loss of accuracy and immediacy. Thus our project is focus on the bio-signal transformation to diversify output methods of biosensor. Following this idea, we design a transducer which can convert the change of gene expression level that stimulated by inducer directly into the electric signal via inductive synthesis ( or destroy ) of nanowire between the electrodes. Curli fiber, a well characterized amyloid fiber which forms β-sheet-rich amyloid fibers, seems to be an ideal foundation of our nanowire structure. CsgA, the modified morphon protein of curli fiber with the ability to bind nano gold particles, will play the role as the conductor."
+},
+{
+"Team":"Tokyo-NoKoGen",
+"Year":2014,
+"Description":"Exterminator coli: an engineered E. coli to safely eradicate roaches",
+"Abstract":"Many pesticides use neurotoxins that show toxicity not only to insects but also towards other species, including mammals. We therefore set out to construct an E. coli that can safely eradicate cockroaches but not affect mammals. Cockroaches and many other insects store their energy in the form of trehalose and use the enzyme trehalase to convert it to glucose when needed. Our engineered E. coli will overexpress the enzymes OtsA and OtsB to produce trehalose, and glucose-3-dehydrogenase to convert trehalose to 3,3’-diketotrehalose, an inhibitor of trehalase that is not toxic for mammals. Our engineered Exterminator coli will help eradicate roaches from homes without harming humans or pets."
+},
+{
+"Team":"Tokyo Tech",
+"Year":2014,
+"Description":"Bank E. coli",
+"Abstract":"This year, our team Tokyo_Tech designed Escherichia coli which can act like a bank. As everybody knows, bank is a place where we deposit and withdraw money. In order to mimic this system, we made E. coli accumulate and excrete phosphate just like what bank does with money. This “Bank E. coli” enables you to deposit and withdraw phosphate any time you like. Additionally, bank has another function as a central bank, which controls the amount of money in the market. We designed a system consisted of three kinds of E. coli: imitating bank, company and customer. In this system, they exchange signal molecules as currency. By using the cell-cell communication, we are trying to make our “Bank E. coli” work as a signal molecule stabilizer like a central bank."
+},
+{
+"Team":"Tongji",
+"Year":2014,
+"Description":"Decolor Four",
+"Abstract":"XynB, ArfB and ManA1 are three different decolor-assistant proteins. With the help of these proteins, the pulp (which then becomes paper) can be bleached by much less chemical reagent, to save the environment. Nowadays bio-assistant bleaching method is becoming popular in paper making industry. In our project, we build the parts for these three decolor-assistant proteins to assemble a decolor-assistant machine, and design experiments to see whether these three proteins have synergistic effect. We will also use different kinds of paper pulp to do experiments. Furthermore, we try to make a ready-to-use and user-friendly decoloring solution, based on our synergistic decolor-assistant bacteria."
+},
+{
+"Team":"Toulouse",
+"Year":2014,
+"Description":"Let’s save our trees with SubtiTree!",
+"Abstract":"A threat, originated from the fungus Ceratocystis platani, affects the gorgeous plane trees in one of the most beautiful sites in Southern France named “Canal du Midi”. The Toulouse iGEM team is committed to protecting this UNESCO World Heritage site and has designed a bacterial cure named SubtiTree. This engineered bacterium derives from the natural Bacillus subtilis species present in the plane tree sap. SubtiTree’s mission is to detect, bind and destroy the pathogenic fungus. First, a chemotaxis module directed towards the N-Acetylglucosamine released by the fungi confers the ability to head for the pathogen. Secondly, the bacterium binds to the fungal cell wall via a chitin binding domain. The final step is to kill the pathogen using an antifungal triple therapy. Different strategies are developed to control the spreading of our smart bacterium in the environment. SubtiTree opens new perspectives to vanquish many fungal associated diseases in plants."
+},
+{
+"Team":"Toronto",
+"Year":2014,
+"Description":"Plasmid-Loss Genetic Safeguard for the Biocontainment of Synthetic Organisms",
+"Abstract":"Conventional genetic safeguards for the biocontainment of synthetic organisms often rely on various suicide mechanisms. However, these “kill-switches” suffer from a fundamental flaw since they impose selective pressure on organisms to evolve inactivation of the genetic safeguard. The activation of a kill-switch removes all individuals containing intact kill-switches from the population, leaving behind only individuals with defective kill-switches to found a new population. This project proposes an inducible plasmid-loss system to remove genetically engineered traits from a population without imposing selective pressure against the safeguard itself. The inducible plasmid-loss system is implemented by creating a plasmid containing CRISPR/Cas9, an RNA-guided nuclease system which targets and cleaves itself. A population containing this plasmid is expected to revert to wild-type upon activation. In addition to encouraging the application of evolutionary approaches to the field of synthetic biology, this project also contributes to making synthetic organisms safe for routine use outside the lab."
+},
+{
+"Team":"Tsinghua",
+"Year":2014,
+"Description":"Type I Diabetes Mellitus Gene Therapy",
+"Abstract":"Type I diabetes mellitus (T1DM) affects more than 17 million people worldwide, and current treatments for T1DM, known as insulin therapy, require continued insulin injection, diet control, and constant monitoring of blood sugar. While gene therapy methods that restore insulin production in non-pancreatic cells might provide a one-shot cure for T1DB. We propose a gene therapy for T1DM using an adeno-associated viral (AAV) vector that transfects somatic cells with an insulin gene controlled by a glucose-sensitive promoter, thus potentially able to restore glucose-regulated insulin production in diabetic patients. Preliminary testing is conducted on cell lines to assess the efficiency of the therapy."
+},
+{
+"Team":"Tsinghua-A",
+"Year":2014,
+"Description":"Marvelous TALE-- A Better Gene Edit Tool",
+"Abstract":"Transactivator-Like Effectors (TALEs) are a technology that once revolutionized the way researchers manipulate DNA with exceptional site specificity.Though it works well in eukaryotic organisms, it is not available in prokaryotic organisms. We come up with the idea that the long repeating sequence of the TALEs coding sequence leads to it. In our project, we attempt to construct a marvelous TALEs system which can efficiently work in prokaryotic organisms. By optimizing the TALEs coding sequence with modeling methods and testing it by Golden Gate Assembly and Report System, we hope we can have a handle tool for gene editing in prokaryotic organisms."
+},
+{
+"Team":"TU Delft-Leiden",
+"Year":2014,
+"Description":"Using ELECTRACE to detect landmines",
+"Abstract":"Our team will develop a microbial based sensor –ELECTRACE. The great innovation of our project consists on the biosensor’s ability to produce a directly measurable electric signal as output. Electrical conductivity is a novel output that is orthogonal to all other standard outputs currently in use, such as fluorescence. In this way we will overcome the difficulties that arise by using conventional output signals, which are hard to quantify and to use outside the lab. The sensor-output system will be implemented in a microfluidics set-up, offering the possibility of designing a cost effective device that could be used at a large scale. ELECTRACE enables the interface between biology and electronics and fundamentally broadens the range of applications for synthetic biology. As a proof of principle, we will realize a system that is able to detect landmines. Additionally, the pathway that will be implemented can be extended to several other applications."
+},
+{
+"Team":"TU Darmstadt",
+"Year":2014,
+"Description":"E. Grätzel – Solar BioEnergy",
+"Abstract":"This year the team aims to achieve victory in the championship of synthetic biology by investigating a new approach to produce a plant pigment called Anthocyanin in Escherichia coli (E. coli). This class of pigment not only stains blossoms in blue, violet or red but also is enclosed in fruits and is valued for its antioxidant effect as well as the ability to lower the risks for cancer. In the team’s technological approach, the anthocyanin dye can be utilised to build so-called “Grätzel cells”. These electrochemical dye-sensitized solar cells use the produced dye instead of a semiconductor material for the absorption of light. The objective is to investigate an innovative approach for a sustainable energy source; wherever and whenever needed. In the course of the project phase, the team will construct a Grätzel cell testing their dye that was produced in E. coli."
+},
+{
+"Team":"TU Eindhoven",
+"Year":2014,
+"Description":"Click Coli: expanding the chemical toolbox for bacteria",
+"Abstract":"A fundamental problem in utilizing genetically modified bacteria is their limited ability to survive under non-natural conditions, such as the harsh conditions in industrial reactors and the immune system in the human body. We report a “Plug-and-Play” system allowing the introduction of chemical anchors on cell membranes, subsequently used to attach a functional coating. The anchors consist of azidophenylalanine, which couples covalently with molecules containing the strained alkyne DBCO in a so-called “click” reaction. We obtained proof of concept that our developed Clickable Outer Membrane Proteins (COMP) enable this fast and effective click reaction. We apply it to create a safe “clicked-on” coating allowing E.coli to be used in the human body for healthcare purposes. Furthermore, microfluidic devices have been designed, ensuring increased control over the click reaction and single cell coating. We believe our “Plug-and-Play” system is a versatile tool providing numerous possibilities for engineering bacteria on outer membranes."
+},
+{
+"Team":"Tuebingen",
+"Year":2014,
+"Description":"T-ECO: Tuebingen Erythrocyte Converter to O",
+"Abstract":"Blood types within the ABO-system differ in their glycosylation. The oligosaccharide characterizing type O is a precursor for those characterizing types A and B. Thus, shortages of type O blood units, which can be received by people with any common ABO genotype, might be overcome by specific deglycosylation of blood units of type A, B or AB. For this task we will utilize blood antigen-specific glycosidases in combination with different immobilisation tags. Ultimately we aim to create a matrix coated with our enzymes, able to convert blood for transfusion. Of the three enzymes we utilize, two will leave the blood compatible with all common ABO-types, while one will make the blood compatible even with the rare Bombay-blood type (Oh). Additionally we will provide the parts-registry with new protein-tags in the RFC25 standard for fusion proteins, allowing protein-protein coupling as well as immobilization on specifically prepared matrices. "
+},
+{
+"Team":"UANL Mty-Mexico",
+"Year":2014,
+"Description":"The Reprogrammator",
+"Abstract":"The interest on GMOs and their potential exploitability has rapidly grown, but public concerns about their controllability once introduced into the environment have limited their usage. In order to offer a security system, we have designed a stratagem and a series of tools to posses the ability to hack the genetic composition of GMOs, either to “reset” the genetic programmation back to wild-type or to modify it for a different one if an “update” is required. To achieve this, we integrated a DNA delivery system that works in situ and a sequence-specific DNA digestion system that works in vivo. The main advantage our work provides against suicide switches, a different type of security system for GMOs, is that our technology does not trigger a “shut down” to the target organism. As a reliable eco-friendly tool, our system is not able to hack native species, only those developed in the laboratory."
+},
+{
+"Team":"Tufts",
+"Year":2014,
+"Description":"Robust biofilm formation using a cyclic-di-GMP aptamer and investigating ethics and applications of engineered bactiophage",
+"Abstract":"A long, noncoding massively expressed regulatory RNA (merRNA) discovered in Bdellovibrio bacteriovorus is present in high levels during its dormant phase. The merRNA is believed to sequester cyclic-di-GMP, much like a sponge. Since cyclic-di-GMP is a second messenger for various cellular functions, including motility and biofilm formation, the Tufts iGEM team introduced this merRNA sequence into E. coli. Constitutive expression of this merRNA transcript was shown to increase biofilm formation. This property can be useful in microbe-based approaches to environmental remediation. Earlier designs for phage delivery of the merRNA to disrupt biofilms inspired an investigation into the policy surrounding engineered bacteriophage. Tufts iGEM will be convening a panel of experts from various disciplines to put forth recommendations for the responsible use of phage in therapeutic and industrial applications. A proposal will be drafted for a silk bandage containing a phage cocktail which can prevent and treat infection by antibiotic-resistant bacteria."
+},
+{
+"Team":"UB Indonesia",
+"Year":2014,
+"Description":"Cervical Cancer Care+ (C3+)",
+"Abstract":"Cervical cancer is deadliest disease in women, worldwide. The diseases caused by HPV (Human Papilloma Virus) and can be prevented by natural antioxidant consumption, such as tea that has epigallocathecin gallate (EGCG). Precancerous changes of the cervix can be seen with Pap smear test and colposcopy. However, the detections procedure cause uncomfortable and depending on oncologist.Therefore, UB-Indonesia team developed a Cervical Cancer Care + (C3+) to prevent the cervical cancer epidemic. First project, we have developed very simple detection kit for HPV DNA based on colorimetry and equipped with detection software-based of mobile phone applications. The software will suggest user for next step to do according the detection result. Second project, we developed siRNA to over-produce EGCG on tea.Third project, we have developed a robust Screening Cancer Therapy kit (SCT).The SCT provide easy tool to discovery particular drug based on HPV type or personalized patient character for cervical cancer treatment."
+},
+{
+"Team":"UCC Ireland",
+"Year":2014,
+"Description":"SeaDNA and SeeDNA",
+"Abstract":"“SeaDNA”- takes inspiration from the hagfish, which lives on the ocean floor and produces a defensive slime made of filaments with amazing properties. From these filaments we aim make novel biopolymers that are biodegradable, lightweight, thinner than a human hair and potentially stronger than nylon, steel and even Kevlar. We plan to use E.coli cells to mass produce these polymers, that should be very useful in health and medicine, food and manufacturing industries. “SeeDNA”- aims to create a system for bacterial-based DNA detection. We hope to design customizable plasmids and exploit DNA hybridization to detect any specific short DNA sequence as an alternative to PCR. Hybridization of the target sequence to the plasmid results in bacterial cell growth and production of a visible signal. This could be a rapid and cheap diagnostic tool for pathogenic DNA such as HPV, and a revolution in resource poor hospital labs in developing countries."
+},
+{
+"Team":"UChicago",
+"Year":2014,
+"Description":"2014: A Sequence Space Odyssey: Diversifying Mutators to Optimize Directed Evolution",
+"Abstract":"Directed evolution engineers organisms to produce proteins of novel function and industrially relevant biomolecules. Traditionally, in vivo directed evolution relies on physical or chemical mutagens that cause accumulation of toxic and nonspecific deleterious mutations. A novel system, termed feedback-regulated evolution of phenotype (FREP), overcomes these problems by incorporating a variable mutation rate system to mimic natural evolution. This is achieved through the dynamic control of a mutator element negatively regulated by the desired end product. The 2014 UChicago iGEM team implemented and optimized FREP in E. coli, using the tyrosine pathway as a proof of concept. We combined multiple mutators with different b deeper exploration of the search space, increasing the initial mutation rate and speeding the accumulation of beneficial mutations. Eliminating mutational bias should increase sequence space search efficiency, significantly improving the process of directed evolution for industrial production of any biomolecule."
+},
+{
+"Team":"UC Davis",
+"Year":2014,
+"Description":"Fast, inexpensive and reproducible quality control of olive oil though enzyme-mediated aldehyde profiling",
+"Abstract":"Olive oil is one of the most common, healthiest and yet widely mislabeled every day diet products. Recent studies found that more than 69% of the extra virgin oil sold in US supermarkets is rancid, while no inexpensive testing method is currently available to consumers. Our team has developed a rapid, inexpensive and accurate technique to measure oil quality. We have built an electrochemical sensor that incorporates engineered enzymes to detect a spectrum of aldehydes that serve as a proxy of rancidity. Computational analysis and custom hardware that includes signal filtering, processing and optimization of chemical kinetics allows us to perform multi-compound detection and hence olive oil quality control in a highly reproducible manner. Current and future collaboration with olive oil producers and distributors will pave the way for a widely-applicable platform with far-fetching consumer applications."
+},
+{
+"Team":"UCL",
+"Year":2014,
+"Description":"The Azo-Remediation Chassis: a bioengineered process preventing accumulation of carcinogenic azo-dye products in industrial wastewater.",
+"Abstract":" Azo-dyes are the main synthetic chemical colourant used in industrial manufacture of clothing, cosmetics, food, and more. During the dyeing process of materials, unbound azo-dyes are washed off into water bodies as industrial/wastewater effluent. Some azo-dyes, and their breakdown products, have proven to be of major environmental and health concern worldwide due to their mutagenic potential. The UCL 2014 team proposes harnessing various azo-dye degrading enzymes to create BioBricks for a novel Azo-Remediation Chassis (ARC). This would be capable of sensing, degrading, and decolourising azo-dyes, and ultimately detoxifying the breakdown products created. A bioprocess employing the ARC in an industrial setting has been developed and various modes of operation explored. This may serve as an end-of-pipe, lucrative addition to facilities expelling azo-dye contaminants. Furthermore, xenobiological approaches to biosafety are considered and a proposal for an “azotrophic” organism paves the way for a new era in synthetic biology biosafety."
+},
+{
+"Team":"UCLA",
+"Year":2014,
+"Description":"Programming Synthetic Fibers: Strong as Steel Meets Soft as Silk",
+"Abstract":"Spiders have evolved an arsenal of silk threads for various applications, using combinations of highly-repetitive silk proteins. These fibers have an extremely high range of tensile strength and elasticity, and along with their low immunogenicity, are desired by the military, medical, and fashion industries. However, spider silk farming is impractical, and alternatives are necessary for large-scale production. Inspired by nature’s design, we aim to engineer E. coli to produce genetically programmed synthetic fibers, and standardize the customization of their physical and functional properties. We have adapted Iterative Capped Assembly to modularize and flexibly control the assembly of silk domains that confer strength or elasticity in specific ratios. Varying the composition of the silk genes, or adding other functional proteins will allow precise fine-tuning of the resulting properties, and expand their practical utility. This platform can be readily applied to assemble other highly-repetitive proteins, or large genes from libraries of parts."
+},
+{
+"Team":"UC-Santa Cruz-BioE",
+"Year":2014,
+"Description":"Increasing Coulombic Efficiency and Current Density in a Microbial Fuel Cell",
+"Abstract":"The UC-Santa Cruz-BioE team is working to design a self-sustaining microbial fuel cell (MFC) that can run on waste water. Microbial fuel cells use bacteria to metabolize organic compounds from waste water and generate electricity under anaerobic conditions through electron transfer to an anode. For our project we plan on engineering Shewanella oneidensis as our electrogenic host. Our first goal is to increase the coulombic efficiency that is lost by Shewanella’s preference to turn acetyl-CoA into acetate, as opposed to metabolizing it through the citric acid cycle[2]. Our second goal is to increase the efficiency of the MFC by altering growth patterns of the bacteria. Current density has been shown to be dependent on biofilm formation by the electrogenic bacteria within the MFC[8]. Therefore we plan to increase current density by increasing biofilm growth."
+},
+{
+"Team":"UC Santa Barbara",
+"Year":2014,
+"Description":" Pathogen Detection using an Engineered Contact-Dependent Inhibition System",
+"Abstract":"The war on microbial pathogens is a complex issue, and will continue to be in the foreseeable future. Antibiotics target microbes once they have invaded their host, but this practice cannot continue forever due to bacteria’s ability to become resistant to the drugs administered. Here, we describe a novel use of recombinant biotechnology to generate Escherichia coli capable of both sensing and reporting the presence of pathogenic bacteria, by taking advantage of a pre-existing contact-dependent inhibition system. Coupling this contact-dependent system to gene control allows us to create a reporter bacterium that will glow on contact with pathogenic bacteria, exposing potential pathogens before they have a chance to infect their host. Dealing with post-infection situations will always be a necessity, but early detection and prevention will certainly lighten the load on an already strained scientific and medical community."
+},
+{
+"Team":"UCSC",
+"Year":2014,
+"Description":"Engineering A Halophillic Archaeon For Butanol Production",
+"Abstract":"Today our energy needs are met by burning ancient fuels, accumulated from historic, decayed organic carbon, and stored deep in the earth. Every atom of this ancient carbon was once present as a simpler molecule, synthesized to more complex carbon molecules by plants using solar power and through our burning, returned to the atmosphere in a multi-thousand year cycle. Today, we are burning more of this “slow-solar” petroleum than is being made and we accumulate CO2 as a greenhouse gas. We intend to directly address global CO2 accumulation through a “fast-solar” strategy that relies on rapid conversion of cellulose from plants to an energy-rich liquid fuel. For 2014, Team UCSC will focus on production of butanol fermented by a salt-loving microbe."
+},
+{
+"Team":"UCSD Software",
+"Year":2014,
+"Description":"SBiDer: Synthetic Biocircuit Developer",
+"Abstract":"Genetic circuits are often difficult to engineer, requiring months to design, build, and test each individual genetic device involved in the circuit. SBiDer, a web tool developed by the UCSD Software iGEM team, will leverage existing devices to construct a database with consideration for the function of each device interpreted as boolean logic. The data can be queried by the user through SBiDer’s visual interface to explore circuit designs. The displayed circuit’s literature reference, characterization data, and images of included devices can be viewed through the built-in table. Basic validation of the circuit performance is also provided within in the interface. SBiDer’s web of information can be expanded through user-generated additions to the database to improve the efficiency of the application and the accuracy of the models."
+},
+{
+"Team":"UESTC-China",
+"Year":2014,
+"Description":"Plants vs HCHO",
+"Abstract":"Our team, named UESTC_China, is from one of the most livable city, Chengdu, the hometown of pandas. Even before we decided what to do in this game, we all agreed on that we should do something to save our planet. And then came the idea of “Plants vs HCHO”. HCHO is toxic gas appears in every single room which is newly decorated. Not only is it smelly, but also cause various of desease, like skin and mucous membrane irritation, immunity or memory decline, drowsiness, fatigue, cancer, allergic dermatitis. To remove HCHO, we added FALDH, FDH,HPS/PHI to increase our plant’s ability for absorbing and degrading formaldehyde. There are other two more important enzymes in our project. One is to enlarge the stoma, and another is for male sterility system which for safety. In the future,we sincerely cherish the hope that our work will be put to use in our everyday life."
+}, 
+{
+"Team":"UCSF UCB",
+"Year":2014,
+"Description":"Sense and Secrete-ability",
+"Abstract":"Cells in a local population have a wide range of responses to a given stimulus, potentially due to differences in extracellular environment or intracellular molecular composition. However, cellular communities often need to resolve this variation to respond in a concerted and robust way. Our project seeks to understand complex intercellular interactions underlying specific community phenotypes by engineering communication motifs with the goal of reaching a community behavior to either converge or diverge in response. To do this, we have engineered novel sense-and-secrete circuits into yeast. To model community signaling, we repurposed endogenous yeast mating factor alpha(MFα) as an extracellular signal. Our designed circuit outputs initial individual responses to stimuli as GFP signal and, after signaling through secreted MFα, a downstream community-coordinated response is reported as RFP signal. By tuning parameters like positive and negative feedback strength and MFα-sensitivity, we hope to develop a circuit capable of analyzing cellular community interactions."
+},
+{
+"Team":"UESTC-Software",
+"Year":2014,
+"Description":"CRISPR-X: a sgRNA design tool for genome editing in synthetic biology ",
+"Abstract":"Just like “Plants vs. Zombies” has become one of the most popular games, CRISPR/Cas system learned, borrowed and modified from the natural game “Bacteria vs. Phages” has been the hottest technology for genome editing. The CRISPR craze wept across scientific community last year. Synthetic Biology and iGEM were no exception. The sgRNA design tools are an important part for CRISPR/Cas technology. However, all available tools neglect the purpose of a given experiment, pay no attention to BioBricks standards, and do not support standard for synthetic biology data exchange (SBOL). Thus, a sgRNA design tool for genome editing in synthetic biology is desirable. In this project, we present CRISPR-X, a sgRNA design tool fully supporting SBOL and BioBricks standards with dynamic algorithm based on intent function, chassis, and newest experimental data. The program can be used on all platforms."
+}, 
+{
+"Team":"UFAM Brazil",
+"Year":2014,
+"Description":"Mercury Bacter ",
+"Abstract":"Mercury (Hg) is a widely used metal in mining and industrial processes. It’s easily spread in the environment and is considered a global pollutant, even reaching environments which have never been exposed to it. Among the contaminant metals, Hg is one of the most toxic and the only one able to undergo bio-magnification in most food chains. Besides, being the only known metal that causes human death through ingestion of contaminated aquatic organisms. To solve this problem, we used a bacterial mechanism of mercury resistance - operon mer - as inspiration. Mer operon is composed mainly by MerR, MerT, MerP and MerA proteins responsible for transport and reduction of mercury, being up regulated in its presence. Our project aims to develop contaminated water’s treatment using mer proteins for bioremediation, attach a fluorescent protein for bio-detection and metallothionein for bioaccumulation in order to reduce damage caused by mercury in the ecosystem."
+},
+{
+"Team":"UGA-Georgia",
+"Year":2014,
+"Description":"ESTABLISHING METHANOGENIC ARCHAEA AS AN ALTERNATIVE PLATFORM FOR SYNTHETIC BIOLOGY ",
+"Abstract":"When beginning research in synthetic biology, the go-to organism is the bacterium E. coli. Our research demonstrates the utility of a methanogenic archaeon, Methanococcus maripaludis, as an alternative platform. Our two primary focuses in this study are: 1) improving the genetic tools for synthetic biology available in archaea and 2) demonstrating the utility of archaea in synthetic biology through production of geraniol. Previously, a synthesized gene encoding geraniol synthase was expressed in M. maripaludis, and geraniol production was quantified as 0.2% of lipid dry weight using GC/MS. In order to optimize geraniol production, we are experimenting a combination of chemical, biological and computational approaches that include: an improved geraniol extraction procedure resulting in better recovery, a fluorescent protein monitor for protein expression and regulation, a synthetic ribosome-binding-site library enabling variable levels of expression, and a metabolic model of the lipid biosynthesis pathway subjected to flux balance analysis. "
+},
+{
+"Team":"UFMG Brazil",
+"Year":2014,
+"Description":"The Colonyeast",
+"Abstract":"Colorectal cancer is a widespread form of cancer that develops on the large intestine. Its diagnosis requires extremely invasive techniques, such as colonoscopy, which is one of the main problems associated to its early detection. On our institution, a modified probiotic strain of Saccharomyces cerevisiae was isolated from local beverage. Our objective is to introduce this strain as a new probiotic chassis on iGEM, and also to develop a gene circuit that allows it to detect one or more stool biomarkers for colorectal cancer on the intestine. We chose L-DNA (long DNA molecules) as biomarker, and designed a chimeric protein using TALE DNA-Binding Domains and a split version of mCherry that can detect certain repetitive sequences on DNA and emit fluorescence, which when measured serve as proxy for the DNA size."
+},
+{
+"Team":"UI-Indonesia",
+"Year":2014,
+"Description":"Mission i(GE)Mpossible: Vibrio Espionage",
+"Abstract":"Biofilm is a matrix extracellular polymeric substances (EPS) that is surrounding microbial collonies. It causes more than 65% of all microbial infections. Most of pathogenic bacteria could make biofilm that can cause antibiotic resistance issue and increase its pathogenecity. Our Escherichia coli can degrade biofilm from various bacteria after it seeks them by detecting their quorum sensing molecule. Our team will focus in Vibrio cholerae because it is a cause of cholera as a deadly tropical countries disease. We present our E. coli agent that can degrade biofilm of V. cholerae after it can detect quorum sensing molecule from V. cholerae, CAI-1, by CqsS receptor. Then our E. coli agent will activate motility gene, CheZ, to hunt V. cholerae. When it arrives, our bacteria will degrade the biofilm by secreting enzymes, such as α-amylase, nuclease, and substilisin to break down the matrix and peptide 1018 that will kill V. cholerae."
+},
+{
+"Team":"UiOslo Norway",
+"Year":2014,
+"Description":"MicrOrganizer – The E.coli bodybuilder",
+"Abstract":"We are aiming to build a system for organizing E. coli in a predetermined way, a MicrOrganizer. We are trying to create biobricks that gives E. coli surface identity, and at the same time binds one E. coli bacterium physically to another E. coli bacterium. This binding will also transfer a signal to the inside of the bacteria and induce gene expression. We want to do this by using the split enzyme principle of the LacZ gene. This gene codes for β-galactosidase which can be split into two parts: β-galactosidase α and β-galactosidase β. The functional enzyme consisting of one alpha and one beta part hydrolyses lactose into galactose and glucose. This process produces on some occasions allolactose which can be transported back into the bacteria and induces the Lac-operon, and thus gene expression. To express each enzyme part on the bacterial surface we will couple them to autotransporter proteins."
+},
+{
+"Team":"ULB-Brussels",
+"Year":2014,
+"Description":"Mighty Coli, addicting bacteria to protein production",
+"Abstract":"Our aim is to enhance recombinant protein production in bioreactors by making microorganisms addict to the production of a protein of interest (PI). We built MightyColi, a recombinant Escherichia Coli expressing a toxin and a PI. This protein will be on the same open reading frame than an antoxin, a protein able to neutralize the effects of the toxin. Stressed subpopulations might not express the PI (and thus the antitoxin) to a sufficient level, allowing the toxin to kill unproductive cells. Our work will consist on building and modelling this system."
+},
+{
+"Team":"UIUC Illinois",
+"Year":2014,
+"Description":"Puppy Probiotics: Theobromine Degradation by an Engineered Lactobacillus plantarum",
+"Abstract":"The stimulant theobromine is an alkaloid found naturally in cocoa trees and chocolate. Due to metabolic inefficiencies, canines cannot digest theobromine as quickly as humans can, thus leading to an excess of the stimulant in the gastointestinal tract. Even small amounts of chocolate can induce toxic side effects such as nausea and even death in canines. However, by manipulating theobromine via N-demethylases, it can be metabolized into xanthine, which is much safer for animal digestion. By repurposing a previously characterized caffeine degradation operon into Lactobacillus plantarum, we aim to create a probiotic that can sustain theobromine N-demethylation while simultaneously colonizing canine guts. We will also incorporate modeling with our experimental data to determine the feasibility of our novel probiotic strategy."
+},
+{
+"Team":"UMaryland",
+"Year":2014,
+"Description":"Engineered E. coli Biosensors for the Oyster Pathogen Perkinsus marinus",
+"Abstract":"The population of Crasseoterra virginica, the Eastern oyster, is a fraction of what it once was. A major reason for this decline is the spread of Perkinsus marinus, a protist that infests oyster cells, causing tissue damage and eventual oyster death. P. marinus infection requires recognition of a four-domain galectin protein, CvGal1, produced by oyster hemocytes to capture bacteria by binding surface sugars. P. marinus targets CvGal1 using unknown carbohydrate ligands on the protest surface. As a first step in generating a bacterial biosensor for P. marinus, a recombinant OmpA-CvGal1 protein was engineered to anchor on the E. coli outer cell membrane. OmpA fusions with mammalian two-domain galectins were similarly engineered to investigate the effect of galectin size on the efficiency of membrane display and pathogen recognition. The receptor was designed to couple to a defensive response, such as the production of anchored beta-galactosidase to cleave P. marinus recognition ligands."
+},
+{
+"Team":"UMayor-Chile",
+"Year":2014,
+"Description":"E. coli Trojan horse invading biofilms",
+"Abstract":"The cystic fibrosis (CF) it’s a mutation in the glycoprotein CFTR (that have a rol as a chloride channel), which affects the entire system, including the immune system. When a patient is diagnosticated with Pseudomonas aeruginosa in his lungs, it is too difficult to eradicate it. One reason of this it’s the biofilm generated by P. aerugunosa, which protects this opportunistic pathogen from any attack, including the treatments with antibiotics. Our project aims to generate a bacteria capable of weakening the biofilm breaking one of the main components of this protection: the arginate; and shutting down the communication between the Pseudomonas colonies. The E. coli is capable to use the biofilms, making it a good candidate for use as a Trojan horse. We going to test the above mentioned functions in this chassis, using in vitro biofilms."
+},
+{
+"Team":"uOttawa",
+"Year":2014,
+"Description":"Engineering Fate: Creating Autonomous Decision making in Yeast",
+"Abstract":"Cellular decision-making is the process by which cells assume unique, functionally different states, to address various needs of an organism. However, due to a lack of well-characterized devices capable of producing multiple states, the design of organisms with multiple changing functionalities has been hampered. This year, we have engineered yeast that can make multiple decisions based on environmental cues and indefinitely maintain their state until conditions change. We will achieve this by implementing a synthetic cellular decision making transcriptional network: the tri-stable switch. We have designed and tested new dual input promoters that use transcriptional activators as both activators and repressors. We have also generated a mathematical model of our system from our constructed promoter characterizations, along with continuing with our outreach program to elementary and high school students. We believe that by emulating cellular decision making mechanisms we will, one day, be able to manipulate existing systems."
+},
+{
+"Team":"UNIK Copenhagen",
+"Year":2014,
+"Description":"EASY - Engineered Antibody Sensing",
+"Abstract":"The latest spread of emerging infectious diseases like Ebola have shown the need of a fast detection method to monitor outbreaks and take further actions. Here are biosensors an attractive tool to take the job. Cecilie, Henrik, Morten and Owik are competing for the University of Copenhagen in the iGEM competition 2014. With our idea of using an antibody-fluorophore agent as a biosensor we are able to combine the high affinity of an antibody with the simple detection method of a fluorophore. With this unique setup we are able to simplify the detection as well as reduce costs and time. Our project EASY is exploring the opportunity of new detection methods for various antigens as hormones or virus proteins. Meet the team and join our journey to the next generation of biosensors."
+},
+{
+"Team":"UST Beijing",
+"Year":2014,
+"Description":"Proteorhodopsin in Mitochondria",
+"Abstract":"Synthetic biology is an emerging field which combines forward-engineering technology with that of conventional biochemical and molecular genetics approaches, also considered “reverse engineering” of terrestrial life systems. Since first established in 2003, the iGEM competition, a college level education platform, encourages the practice of genetic engineering using standardized function-oriented DNA fragments; in recent years especially, iGEM projects have become increasingly sophisticated, and some winning ones have reached the limit of logical reasoning and design. Our 2011 UST-Beijing team took the initiative of exploring horizontal gene transfer, by inserting a bacterial light-driven proton-pump into the inner mitochondrial membrane of cultured human cells. This year, for the 2014 iGEM competition, our UST-Beijing team will continue to analyze the transformed human cells, and make further proposals based on the unique observation of these experiments, in order to promote health and human welfare."
+},
+{
+"Team":"Uppsala",
+"Year":2014,
+"Description":"Bactissiles: The future of microbial combat",
+"Abstract":"Destabilized ecosystems and disturbed gut floras are both consequences of treatments that lack selectivity. More efficient and precise methods are needed. This year we, the Uppsala iGEM team, tries to widen the view and find new possibilities with engineered bacteria. By developing a system that homes towards a target and secretes an affectant, we can ensure a specific outcome. Such a system could have applications in a number of different fields, though we have chosen to put this into practice in a pinpointing pathogen-killing approach. In our prototype system, introduced in E. coli, we hijack the quorum sensing system of the gut pathogen Yersinia enterocolitica. Our bacteria will be able to sense the presence of the pathogen, accumulate in its vicinity and emit a target-specific bacteriocin, leaving the remaining gut flora intact. The era of mass destruction is over. Welcome the missile bacteria, the Bactissile!"
+},
+{
+"Team":"USTC-China",
+"Year":2014,
+"Description":"C.imager",
+"Abstract":"In this project, our aim is to design and construct a colorful bio-imaging system----Once you project a picture on engineered C.cresentus, they present the same image accurately, and it’s even flourescent! We took advantage of the nature of Caulobacter crescents (C.crescents), which is the ability to attach to a diverse range of surface by developing holdfast, to design circuits in C.crescentus in which light of different wavelength and intensity could trigger expression of corresponding florescent proteins as well as the enhancement of holdfast. So that C.crescentus can locate themselves correctly and present image colorfully. We also found that allosteric RNA operating as riboswitch is a promising alternative to proteins for synthetic chemical circuits due to its many distinct advantages such as rapid response and specificity. So we designed logic gates base on RNA switches to replace previous passway to create a faster C.imager."
+},
+{
+"Team":"USTC-Software",
+"Year":2014,
+"Description":"BioPano-A platform which helps you figure out relationships between various substances in the bacteria",
+"Abstract":"BioPano is a data visualizational open source software specially designed for biologists, which can be used to show gene regulation and metabolic network. When a node is selected, our software can quickly form a net with the nodes close to it. When a gene sequence is provided, such as a BioBrick part, our software can use homology method to predict the impact it gives on the gene regulatory network. Furthermore, the software provides users with various interfaces so that the entire network, or a part of it, can be exported into corresponding format which can be imported into other professional softwares for network analysis.On this platform, users can create, modify and complete different biological networks based on the information they get from online collaboration."
+},
+{
+"Team":"UT-Dallas",
+"Year":2014,
+"Description":"Bactericidal and Bacteriostatic Probiotics: targeting infectious agents of the human gut through a genomic approach.",
+"Abstract":"Treating infectious diseases of the gastrointestinal (GI) tract with antibiotics disrupts a patient’s gut microbiota and can increase the prevalence of antibiotic resistant strains. The increasing population of multi-drug resistant bacterial strains, both within and outside of health centers, is a growing health concern that is becoming progressively difficult to treat.We envision a new paradigm for treating infections of the human gastrointestinal tract through exploitation of engineered probiotics that produce anti-microbials with high specificity for pathogens at the genome level. Toward this end, we will utilize the CRISPR/Cas9 system with gRNA engineered to recognize genes from infectious bacteria. Our CRISPR/Cas9 system will be delivered from the engineered E. coli to infectious bacteria using bacterial specific phages, minimizing any side-effects to native microbiota and human-host cells. As a proof-of-principle for our engineered probiotic, we start by targeting the pathogenic bacterium Vibrio cholera."
+},
+{
+"Team":"USyd-Australia",
+"Year":2014,
+"Description":"Integrons as a novel cloning system in E. coli",
+"Abstract":"Integrons are systems that can capture and utilise mobile genetic elements known as gene cassetes, and which are found in a vast array of bacteria, often associated with antibiotic resistance. Gene cassettes with an attC recognition site are site selectively recombined into an attI recognition site by the integron integrase. We are seeking to design biobrick compatible integron components that can be used as a novel, convenient and selective cloning system in lab strains of E. coli, which normally do not contain integron systems. Additionally, we are investigating regulation of natural transformation mechanisms in E. coli in an attempt to allow uptake and recombination of attC containing genetic elements with added convenience. This will include investigating the role of the transcription factor sxy, as well as other components of the DNA uptake systems of other gram negative bacteria that are naturally transformable."
+},
+{
+"Team":"Utah State",
+"Year":2014,
+"Description":"Stain Busters",
+"Abstract":"Laundry detergents are one of the most commonly used household cleaning products in today’s society because they effectively clean and remove stains from clothing. Even though they are relatively harmless to humans, laundry detergents contain caustic chemicals and reagents that have a detrimental impact on the environment. Our aim is to use enzymatic means of cleaning to reduce the amount of detergent necessary for normal washes as well as increase the efficiency of stain removal. We have engineered E. coli to produce enzymes that can be used to remove laundry stains such as grass, starch, and oils. By functionalizing these enzymes on a bioplastic material that can be used as an additive to traditional laundry cycles, we hope to improve the sanitation of clothing and other washable materials. The demonstration of enzyme functionality after biological immobilization will create a platform for future teams to display enzymes relevant to other applications."
+},
+{
+"Team":"UT-Tokyo",
+"Year":2014,
+"Description":"σ-Recounter",
+"Abstract":"In synthetic biology, Genetic memory devices have been constructed and applied widely from Biocomputing to biomedical technologies as a crucial component. Such memory devices include a cellular counter; a fundamental device which memorizes the number of induction events. Recent efforts have resulted in a cellular counter that can count up to three events. However, this counter cannot be reset to its initial state. Here, we propose a resettable cellular counter called “sigma recounter”. This counter utilizes the regulation system of sigma factor and anti-sigma factor as the key of its resetting mechanism. In this system a set of sigma factors are designed to update and maintain a count that responds to each inducted event. By the other stimulus, the system initiates a genetic circuit that can express a suitable set of anti-sigma factors and erases the existing memory, which will enable our device to restart the count from any state."
+},
+{
+"Team":"Valencia UPV",
+"Year":2014,
+"Description":"The Sexy Plant",
+"Abstract":"The Sexy Plant offers a sustainable alternative to current pest management and crop protection techniques, which nowadays rely on pesticides and chemically synthetized pheromones, which are chemical signals that insects use to communicate. We are developing a synthetic plant capable of producing insect sexual pheromones and releasing them into the air. High concentration of sexual pheromones into the air prevent male insects from finding the females. Using this mate disruption strategy, damage in crops caused by larvae is avoided. Since the Sexy Plant is implemented with a genetic switch and a biosafety module, it rises as a strong, safe and environmentally friendly candidate as the pest management method of the future."
+},
+{
+"Team":"Valencia Biocampus",
+"Year":2014,
+"Description":"The ST2OOL Project ",
+"Abstract":"The STOOL project aims at deeply studying four of the key engineering pillars of Synthetic Biology. STOOL stands for STandardization, STability, Orthogonality and Open Licence/legal issues. The first approach will consist of a vast range of analytical studies to find out how standard, stable, orthogonal and patentable are several selected Biobrick parts. The second approach will include functional metagenomics: several environmental libraries will be set and screened in E. coli in order to select new biological parts -promoters- not because of their strength but because of their particularly standard, stable or orthogonal behavior. Taken together, the results of our project are expected to contribute to answer this key question: Is life fully engineerable?"
+},
+{
+"Team":"Vanderbilt",
+"Year":2014,
+"Description":"Scenthase: Cellular Terpene Biosynthesis",
+"Abstract":"Long before the advent of modern science, it was recognized that certain plants are capable of producing compounds of immense value. From a single class of molecule, the terpenoids, come properties including agents with therapeutic qualities against maladies ranging from cancer to infection, antimicrobials, natural pesticides, rich flavorants, and fragrant scents. However, the utilization of these remarkable compounds has been severely hindered by their rarity in nature: many are found in only a small number of species and produced at levels measured in parts per million. Synthetic biology offers an opportunity to resolve this problem, by applying metabolic engineering in order to create cellular factories. Our project seeks to use the ideas of synthetic biology to develop a commercially viable strategy for the efficient production of a wide range of terpenoids."
+},
+{
+"Team":"Vanderbilt MF",
+"Year":2014,
+"Description":"E. chrono",
+"Abstract":"The goal of our project is to explore the fabrication of microfluidic devices that can be used as genetic sensors. Our research focuses on the design, fabrication, and testing of microfluidic devices which are suitable for synthetic biology studies. Currently, we are developing an E.coli watch that is able to detect the passage of time based on the fluorescence produced by quorum sensing E.coli. We have developed a novel microfluidic device to test evaluate quorum sensing in E.coli and hope to manipulate other genetic switches in the future for increased sensing capabilities."
+},
+{
+"Team":"Virginia",
+"Year":2014,
+"Description":"NyGone: A Bacterial Biofilter for Nylon Microplastics",
+"Abstract":"Microplastics, small plastic pieces with diameters of 5 millimeters or less which are present in commercial products and form from degrading macroplastics, are a growing threat to both public health and the environment. Our project design is centered on the creation of BioBricks that facilitate the formation of an E.coli biofilm that captures and degrades nylon microplastics. Biofilm formation is achieved through the overexpression of the transcriptional regulator NhaR, which increases the production of poly-beta-1,6-N-acetyl-d-glucosamine (PGA). This exopolysaccharide creates a stable biofilm capable of adhering microplastics. Microplastics are then degraded by manganese peroxidase and nylon hydrolase that are secreted by the biofilm. Using these modified E. coli, our team designed a biofilter to effectively remove the threat of microplastics from water supplies."
+},
+{
+"Team":"Vanderbilt Software",
+"Year":2014,
+"Description":"Darwin: A Version Control System for Synthetic Biology",
+"Abstract":"Darwin is a software package to document changes to DNA which allows for easy, standardized, and collaborative editing on the genome scale. It builds off of tested and proven version control software, allowing easy browsing and transferral of the entire history of the tracked data. Darwin distinguishes itself from other version control systems by focusing specifically on tracking DNA data at the file level, offering significant speed and security improvements over other solutions. Darwin is completely open-source, so any security or optimization issues can be identified and solved immediately to help all users of the tool. Darwin is also agnostic to the type of version control backend used, so it can be put into place on a massive variety of systems. Darwin is a complete solution for change tracking in a single cross-platform solution."
+},
+{
+"Team":"Wageningen UR",
+"Year":2014,
+"Description":"BananaGuard: Biocontrol of Fusarium oxysporum using Pseudomonas putida",
+"Abstract":"Fusarium species are known to infect a wide range of crops and cause large losses in agriculture. Our project aims to use an engineered strain of the native soil bacterium Pseudomonas putida to protect banana plants against Fusarium oxysporum infection. Upon sensing of fusaric acid excreted by F. oxysporum, fungal growth inhibitors will be produced by P. putida to prevent infection of the banana plants. To minimize the environmental impact of the fungal inhibitors to the soil microbiome, the bacteria will contain a kill switch that will cause it to terminate once the threat of F. oxysporum to the bananas has been alleviated. Furthermore, a double dependent plasmid system will be used to prevent the spread of artificial genetic material to surrounding soil bacteria. In summary, we hope to develop a showcase for the use of synthetic biology in agriculture in a safe and sustainable way."
+},
+{
+"Team":"Virtus-Parva Mexico",
+"Year":2014,
+"Description":"The future of combat against diseases: the BioNEMS Drill",
+"Abstract":"Traditionally pathogens have been annihilated using pharmaceuticals, but today nanotechnology offers a new possibility with the use of nanoelectromechanical systems (NEMS). We present a novel device that could make these processes possible: the BioNEMS Drill. This is a magnetic portion of chromatin. To construct the device we synthesized hydrophilic magnetite. We used it due to its bio-compatibility for medical applications and later functionalized them with amino groups, which can establish a peptide bond between nanoparticles and a protein. We used the HU histone-like protein, capable of coiling DNA around the nanoparticles. To get enough protein, we modified E. Coli to overexpress it. Since the core of the device is magnetic it can be controlled by applying an external magnetic field. Furthermore, the versatility of the DNA to be coated with various materials and its functionalization can selectively remove certain chemicals inside the human body such as cholesterol or toxic agents. "
+},
+{
+"Team":"Warsaw",
+"Year":2014,
+"Description":"CeLuLaRE – Lanthanide Recycling System",
+"Abstract":"Recently, interest has been growing in waste recovery of chemical elements due to depletion of some ores, especially lanthanide ones. Our goal therefore involved designing a bacterial system capable of detecting and binding lanthanides. We then proposed a method to extract these ions, hence making the recycling of these valuable metals (e.g. from wastewater) effective. Basing on Salmonella iron-binding system we modified lanthanide binding tags to adjust them to different ionic size. We also used a superfolder GFP to measure the concentration of collected ions. When an ion binds to LBT, a signalling pathway is activated, inducing fluorescence. Our project introduces an eco-friendly retrieval technology for industrially significant elements. We hope that extracted metals will be viable for applications in electronics, including medical devices. To propose possible applications in medicine we prepared a report about some fascinating challenges in that field, thus creating the model of Future Lantan Hospital."
+},
+{
+"Team":"Warwick",
+"Year":2014,
+"Description":"Replicon : Flipping the Switch on Gene Therapy",
+"Abstract":"Disrupting the flow of biological information at the level of mRNA is a safer alternative to conventional gene therapy, wherein insertional mutagenesis can occur through integrating vectors. In addition, the ability to regulate the level of expression of a gene using such vectors proves difficult. Therefore, we aim to create a modular, self-replicating RNA system using Hepatitis C Virus (HCV) derived RNA dependent RNA polymerase (RdRp). This drives production of siRNA directed against the enzyme dipeptidyl peptidase-IV (DPP-IV) which is elevated in type 2 diabetes and is the target of major drug studies. The replicon contains control modules, exhibiting a negative feedback mechanism provided by: an MS2 domain linked to RdRp, thereby controlling RdRp translation and therefore controlling replication, and an aptazyme switch to regulate expression levels of our siRNA. Validation of our system and the testing of modules will be performed in human (Huh 7.5) and E. coli cells."
+},
+{
+"Team":"WashU StLouis",
+"Year":2014,
+"Description":"NitroGENIUS: Engineering E. coli to Fix Nitrogen and Regulating Transcription with Light",
+"Abstract":"We have a nitrogen problem. The atmosphere has a bunch; our crops need it to grow, but they rely on nitrogen fixing bacteria in the soil to utilize it. To keep up with our population growth, farmers are more dependent on inorganic fertilizers (which can be expensive, inaccessible, and harmful) to enrich the soil and increase yield. If only we could engineer crops to fix nitrogen! Endosymbiotic theory states that chloroplasts in plants originally came from a symbiotic relationship between prokaryotes. A certain cyanobacterium, Cyanothece sp. 51142, can photosynthesize and fix nitrogen within the same cell. Another photosynthetic cyanobacterium, Synechocystis sp. 6803, has light activated proteins. Our project is to study the systems in a simpler environment by expressing nitrogen-fixing genes in E. coli, and to work on a light repressed system for gene expression, because the nitrogenase enzyme is poisoned by oxygen, a product of photosynthesis."
+},
+{
+"Team":"Washington",
+"Year":2014,
+"Description":"High Throughput Selection of Stable Protein Variants",
+"Abstract":"Stabilizing proteins is an incredibly important and time consuming task in the field of protein engineering. Our team has developed a high throughput method to select for the increased expression and stability of engineered proteins, making them more amenable to large-scale production in Escherichia coli and other downstream applications. Our method involves the insertion of proteins into a Gal4-VP16 transactivator that binds a promoter directly upstream of a GFP gene. This allows for the subsequent selection of mutants associated with higher GFP output, correlating to higher stability, using fluorescence-activated cell sorting. Additionally, our method utilizes degrons to alter the dynamic range of this GFP output. This revolutionary method is a potentially generalizable alternative to current, labor intensive approaches for the selection of stable protein variants. Engineered proteins selected through this method could be produced in bacteria and aid in the development of thermostable, de novo protein therapeutics."
+},
+{
+"Team":"Waterloo",
+"Year":2014,
+"Description":"Delivering Antibiotic Resistance Gene Silencing Mechanisms to a MRSA Population using Bacterial Conjugation",
+"Abstract":"Methicillin resistant Staphylococcus aureus (or MRSA) is an infection-causing pathogen that poses serious health threats in hospitals and in the community. They are well known for their resistance to all β-lactams due to the expression of the mecA gene from the mec cassette. This year, the Waterloo iGEM team proposes to combat this infection by delivering gene-silencing systems: CRISPRi and RNAi through a Staphylococcus conjugative plasmid. This will effectively disable the antibiotic resistant phenotype over time so that a β-lactam antibiotic can then be administered to kill the MRSA. As a proof of concept, our gene silencing mechanisms will target a YFP gene within a Staphylococcus population. We also propose to improve the efficiency of an existing conjugation plasmid so as to develop a more effective means of delivery between Staphylococcal organisms."
+},
+{
+"Team":"WHU-China",
+"Year":2014,
+"Description":"Formaldehyde Terminator",
+"Abstract":"This year the project of WHU-China is Formaldehyde Terminator, in this project, we use three systems to get access to our target which is about detection and removal of formaldehyde. With the Twice Coloration System, we can know, from the color change, whether there is formaldehyde or not and whether the formaldehyde is eliminated completely. And the Street Cleaner System could change formaldehyde into water and carbon dioxide through several reactions with the help of specific enzymes. The Lysis System can help to split E.coli and release the enzymes into the reaction mixture, in which way it enhances the function of the Street Cleaner System. And with the help of all these three systems, we can detect and remove formaldehyde systematically."
+},
+{
+"Team":"William and Mary",
+"Year":2014,
+"Description":"The Calcium Kit: Tools for the in-vivo sensing and manipulation of calcium",
+"Abstract":"Our project is to create a series of tools for inducing, measuring and counting intracellular calcium spikes in both bacteria and yeast. Calcium is known to be important in its function as a signaling ion in eukaryotic organisms; thus, it is valuable to develop synthetic biology tools for studying calcium ions in cells and for interfacing genetic circuits with cellular calcium dynamics. The tools we are creating with this project will enable future study of calcium in bacteria and yeast, as well as create a groundwork for future genetic circuits to be created to study calcium in these organisms, and, eventually, in multicellular organisms."
+},
+{
+"Team":"WHU-Pharm",
+"Year":2014,
+"Description":" Artificial gene circuits for screening drugs targeting FAS pathway",
+"Abstract":"Obesity is a serious problem all over the world, it increases the likelihood of various diseases, particularly heart disease, type 2 diabetes, obstructive sleep apnea, certain types of cancer, and osteoarthritis. The weight loss pill on the market tody have a big side effect on our health. More over, Fatty acid biosynthesis is essential for cell growth. The Fatty acid Synthase II pathway has attracted considerable attention because it presents multiple potential target for antibiotic development, especially after us elucidating the enzyme structure of each step of this pathway. There are a lot of unknown small molecular that have the potential to inhibit the fatty acid synthesis. For example, there is still a lot of unexplored area of the traditional Chinese medicine. What we need to do is to construct a bio-sensor in order to screen the drug we want in such a big pool."
+},
+{
+"Team":"WLC-Milwaukee",
+"Year":2014,
+"Description":"Sugar Rush",
+"Abstract":"In parts of the world suitable land to raise grazing animals is limited so these animals are either not raised or are malnourished. Animals can get more nourishment from a smaller amount of land if they increase digestion efficiency by converting more sugar polymers (cellulose) from plants into usable sugars. We aim to construct an Escherichia coli strain capable of secreting cellulose-degrading enzymes in an animal’s gut. This strain will contain a plasmid that expresses the bglS, yesZ, and xynA genes from Bacillus subtilis that code for three enzymes that cleave different bonds in cellulose. These enzymes will be secreted from the well-studied probiotic Escherichia coli Nissle 1917 cell by a Type I secretion system whose genes are also engineered into the plasmid. In raising animals with this engineered bacterium, we hope to increase the amount of available calories for nutrient-deprived populations while having minimal effects on established cultural practices."
+},
+{
+"Team":"WPI-Worcester",
+"Year":2014,
+"Description":"Ag-goat-ination: Combating Antibiotic Resistance through Diagnostic Agglutination Assays",
+"Abstract":"Just this year, in a vote held for the Longitude Prize, antibiotic resistance was voted the most pressing issue of our time. One of the biggest causes of antibiotic resistance lies in the farming industry; more than 3 times the amount of antibiotics given to humans are administered to livestock. Over-prescription of antibiotics promotes resistance in both livestock pathogens and natural flora, which can be transmitted to humans through meat and other products. A cheap, quick, and reliable mechanism for detecting and identifying infection is one solution to this problem. We developed an E.coli based cell surface antigen expression system that can be utilized as a diagnostic tool for nearly any viral, bacterial, or fungal infection. The recombinant E.coli are utilized in a direct agglutination test using the host organism’s serum. Our team successfully demonstrated the feasibility of this diagnostic tool using a GFP antibody and antigen pair."
+},
+{
+"Team":"Yale",
+"Year":2014,
+"Description":"Producing a Novel Antimicrobial Surface-Binding Peptide Using an Improved T7 Expression System",
+"Abstract":"Biofilm formation on surfaces is an issue in the medical field, naval industry, and other areas. We developed an anti-fouling peptide with two modular components: a mussel adhesion protein (MAP) anchor and LL-37, an antimicrobial peptide. MAPs can selectively attach to metal and organic surfaces via L-dopamine (L-DOPA), a nonstandard amino acid that was incorporated using a genomically recoded organism (GRO). Because this peptide is toxic to the GRO in which it is produced, we designed a better controlled inducible system that limits basal expression. This was achieved through a novel T7 riboregulation system that controls expression at both the transcriptional and translational levels. This improved system is a precise synthetic switch for the expression of cytotoxic substances in the already robust T7 system. Lastly, the antimicrobial surface-binding peptide was assayed for functionality."
+},
+{
+"Team":"XMU-China",
+"Year":2014,
+"Description":"Pattern formation via pseudotaxis under mathematical control",
+"Abstract":"Pattern formation is a hallmark of coordinated cell behavior in both single and multicellular organisms. It typically involves intercellular communication and intracellular signal processing, which requires different configurations of “sender” cells and “receiver” cells. Pseudotaxis provides us a new way to reprogram chemotaxis. Here we design gene circuits based on E.coli pseudotaxis, which is capable of forming conic curves governed by precise mathematical principle. We introduce orthogonal experiments to figure out the most impact factor of pattern formation. We use computational modelling to explore the laws of pattern formation and pattern changes over time on semisolid medium. Therefore, the precise control of pattern formation under mathematical principle lays the foundation for the development of regulators efficiency characterization, tissue engineering, targeted therapy, 3D printing ,biosafety and fabrication of biomaterials."
+},
+{
+"Team":"York",
+"Year":2014,
+"Description":"EcoCADMUS (E. coli CAdmium DecontaMination Universal System)",
+"Abstract":"Metal and sulfate contaminated wastewater, generated both from industry and mineral processing, is a worldwide problem. Cadmium is one of the most commonly encountered toxic heavy metals in contaminated water and is known to cause severe damage to aquatic biodiversity and to humans. Furthermore, the removal of contaminants from wastewater is mainly based on mechanical/chemical processes that present drawbacks such as inefficiency, high energy costs and high technological cost. The University of York iGEM team has developed a new approach to remove cadmium and sulfates from wastewater using genetically engineered Escherichia coli. Our circuit is activated by a cadmium inducible promoter and is divided into two interconnected mechanisms: (i)increasing sulphate uptake and its targeting into cysteine production by engineering the cysteine biosynthesis pathway; (ii) increasing cadmium uptake and targeting of the free-cysteine into metal binding proteins (phytochelatins) for metal chelation/stabilization inside and outside cell."
+},
+{
+"Team":"Zamorano",
+"Year":2014,
+"Description":"Know your enemy, helping the good guys and stopping the bad",
+"Abstract":" Currently, biotechnology in Latin America faces constraints that limit their social acceptance, mainly due to a lack of or distortion of information available to the general public. The team will first determine the perception of biotechnology undergraduate students through a survey developed for this purpose. Second, we will coordinate and conduct education and information activities with children and youth using synthetic biology activities with the goal to publicize scientific and timely information about this technology. Finally, we will conduct a risk analysis of the E zamofordi organism by the Cartegena Protocol and the Environmental Risk Assessment of genetically modified organisms’ guidelines (ERA). With these we will scientifically demonstrate that the project ¨Know your enemy¨ complies with the established norms of biosafety. If handled according to relevant regulations, as an alternate product through the extrapolation of this evaluation, this is a simple tool for future risk analysis applicable to Central America."
+},
+{
+"Team":"ZJU-China",
+"Year":2014,
+"Description":"GeneSocket",
+"Abstract":"The assembly of genetic circuits is a huge obstacle between designs and achievements in synthetic biology. Many well-known methods, from traditional restriction digestion & ligation, 3A assembly to Gibson assembly, aim to overcome the difficulties but unfortunately get respective defects. This year, ZJU-CHINA seeks to build a gene-insertion system in bacterial chromosome, “GeneSocket”. Clearly different from the in vitro constructing methods mentioned before, GeneSocket, which can be easily combined with existing in vitro methods, makes gene expression more accurate, stable and controllable by assembling genetic elements in chromosome directly. Two core methods, lambda red recombination and recombinase-based bistable switch, are applied. Both are the best choices for achieving the characteristics of GeneSocket. We hope that by using GeneSocket, synthetic biologists can turn their theoretical design into reality faster and better. We want to lead to the revolution in techniques of synthetic biology!"
 }
 ]


### PR DESCRIPTION
All abstracts and team names lifted from the [Giant Jamboree Team Booklet](http://2014.igem.org/Giant_Jamboree/Booklet) with a few changes:
- Michigan didn't have an abstract or project title, so are not included (since there's nothing to search)
- A few (but likely not all) obvious typos corrected as I went through
- Marburg provided with actual abstract, not a copy of London BioHackspace. Similarly, Nevada provided with actual abstract, not a copy of NJAU China.

I didn't install node.js/etc. to test how this runs, but I did validate the file with http://jsonlint.com/ so it would surprise me if it causes problems for you.
